### PR TITLE
Implement Hoogle plugin

### DIFF
--- a/csbot/plugins/hoogle.py
+++ b/csbot/plugins/hoogle.py
@@ -42,13 +42,7 @@ class Hoogle(Plugin):
         #  ]
         # }
 
-        maxresults = 0
-
-        try:
-            maxresults = int(self.config_get('results'))
-        except ValueError:
-            self.log.warn(u'"results" is not an integer!')
-            maxresults = self.CONFIG_DEFAULTS['results']
+        maxresults = int(self.config_get('results'))
 
         if hresp.json is None:
             self.log.warn(u'invalid JSON received from Hoogle')


### PR DESCRIPTION
These many commits implement a Hoogle plugin, which uses the JSON API at http://www.haskell.org/hoogle/ to perform requests.
