### PR TITLE
Automatically create .log on plugins, remove boilerplate

### DIFF
--- a/csbot/core.py
+++ b/csbot/core.py
@@ -51,8 +51,6 @@ class Bot(Plugin):
     #: The top-level package for all bot plugins
     PLUGIN_PACKAGE = 'csbot.plugins'
 
-    log = logging.getLogger('csbot.bot')
-
     def __init__(self, configpath):
         super(Bot, self).__init__(self)
 

--- a/csbot/plugin.py
+++ b/csbot/plugin.py
@@ -182,7 +182,12 @@ class Plugin(PluginBase):
     #: :meth:`config_get`.
     CONFIG_ENVVARS = {}
 
+    #: The plugin's logger, created by default using the plugin class'
+    #: containing module name as the logger name.
+    log = None
+
     def __init__(self, bot):
+        self.log = logging.getLogger(self.__class__.__module__)
         self.bot = bot
         self.db_ = None
 

--- a/csbot/plugins/hoogle.py
+++ b/csbot/plugins/hoogle.py
@@ -1,4 +1,3 @@
-import logging
 import requests
 import urllib
 
@@ -9,8 +8,6 @@ class Hoogle(Plugin):
     CONFIG_DEFAULTS = {
         'results': 5,
     }
-
-    log = logging.getLogger(__name__)
 
     def setup(self):
         super(Hoogle, self).setup()

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from urlparse import urlparse
 
@@ -9,8 +8,6 @@ from csbot.plugin import Plugin
 
 
 class LinkInfo(Plugin):
-    log = logging.getLogger(__name__)
-
     def setup(self):
         """Create exclusion and handler filters.
         """


### PR DESCRIPTION
Title says it all: stop boilerplate of plugins doing `log = logging.getLogger(__name__)` by doing it for them in `Plugin.__init__()`.
