### PR TITLE
Disable configuration saving

### DIFF
--- a/csbot/core.py
+++ b/csbot/core.py
@@ -93,10 +93,6 @@ class Bot(Plugin):
         super(Bot, self).teardown()
         self.plugins.broadcast('teardown', static=False)
 
-        # Save configuration
-        with open(self.config_path, 'w') as cfg:
-            self.config_root.write(cfg)
-
     def post_event(self, event):
         self.events.post_event(event)
 

--- a/doc/writing-plugins.rst
+++ b/doc/writing-plugins.rst
@@ -110,17 +110,13 @@ dictionary in addition to supporting its own API.
 
 An example of using plugin configuration::
 
-    class Bomb(Plugin):
-        """A bomb which remembers if it was armed or not, even across bot restarts."""
-        @Plugin.command('explode')
-        def explode(self, e):
-            if self.config.getboolean('armed', False):
-                print('Boom!')
-                self.config['armed'] = False
-
-        @Plugin.command('arm')
-        def arm(self, e):
-            self.config['armed'] = True
+    class Say(Plugin):
+        @Plugin.command('say')
+        def say(self, e):
+            if self.config.getboolean('shout', False):
+                e.protocol.msg(e['reply_to'], e['data'].upper() + '!')
+            else:
+                e.protocol.msg(e['reply_to'], e['data'])
 
 For even more convenience, automatic fallback values are supported through the 
 :attr:`~.Plugin.CONFIG_DEFAULTS` attribute when using the :meth:`~.Plugin.config_get` or 
@@ -129,21 +125,27 @@ For even more convenience, automatic fallback values are supported through the
 supports and what the default values are by looking at just one part of the plugin source code.  The 
 above example would look like this::
 
-    class Bomb(Plugin):
+    class Say(Plugin):
         CONFIG_DEFAULTS = {
-            'armed': False,
+            'shout': False,
         }
 
-        @Plugin.command('explode')
-        def explode(self, e):
-            if self.config_getboolean('armed'):
-                print('Boom!')
-                self.config['armed'] = False
+        @Plugin.command('say')
+        def say(self, e):
+            if self.config_getboolean('shout'):
+                e.protocol.msg(e['reply_to'], e['data'].upper() + '!')
+            else:
+                e.protocol.msg(e['reply_to'], e['data'])
 
-        @Plugin.command('arm')
-        def arm(self, e):
-            self.config['armed'] = True
+Configuration can be changed at runtime, but won't be saved.  This allows for temporary state 
+changes, whilst ensuring the startup state of the bot reflects the configuration file.  For example, 
+the above plugin could be modified with a toggle for the "shout" mode::
 
+    class Say(Plugin):
+        # ...
+        @Plugin.command('toggle')
+        def toggle(self, e):
+            self.config['shout'] = not self.config_get('shout')
 
 Database
 --------


### PR DESCRIPTION
Having configuration something that can be dynamically modified and automatically saved might sound like a good idea, but actually it has a few problems:
- If the configuration file is edited when the bot is running, the changes will be lost when the bot exits and overwrites the file.
- Heroku doesn't allow writing to the filesystem, so it won't work on the "production" deployment of the bot.
- The "production" bot's configuration could drift out of sync with what is shown in the git repository.
- It's possible to set configuration values that would cause the bot to never start up again properly.

Therefore, I propose that configuration is read-only, and submit these commits to that effect.
