### PR TITLE
LinkInfo: "Unicode strings with encoding declaration are not supported"

### DIFF
--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -157,7 +157,14 @@ class LinkInfo(Plugin):
             return None
 
         # Attempt to scrape the HTML for a <title>
-        html = lxml.html.document_fromstring(r.text)
+        html = None
+        try:
+            html = lxml.html.document_fromstring(r.text)
+        except ValueError:
+            # ValueError is usually "Unicode strings with encoding declaration
+            # are not supported", so let's try again without decoding the
+            # content ourselves.
+            html = lxml.html.document_fromstring(r.content)
         title = html.find('.//title')
 
         if title is None:


### PR DESCRIPTION
Looks like lxml exploded when trying to parse http://www.w3.org/TR/REC-xml/.  Should investigate to see (a) why it's getting a strange unicode string from requests and (b) what we should do to make lxml happy.

Traceback:

```
2012-09-20T10:24:54+00:00 app[worker.1]: Traceback (most recent call last):
2012-09-20T10:24:54+00:00 app[worker.1]: exceptions.ValueError: Unicode strings with encoding declaration are not supported.
2012-09-20T10:24:54+00:00 app[worker.1]: Unhandled Error
2012-09-20T10:24:54+00:00 app[worker.1]:     value = etree.fromstring(html, parser, **kw)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "parser.pxi", line 1585, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:90542)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "lxml.etree.pyx", line 2969, in lxml.etree.fromstring (src/lxml/lxml.etree.c:61225)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2413, in dataReceived
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/twisted/protocols/basic.py", line 564, in dataReceived
2012-09-20T10:24:54+00:00 app[worker.1]:     basic.LineReceiver.dataReceived(self, data.replace('\r', ''))
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2421, in lineReceived
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/core.py", line 222, in lineReceived
2012-09-20T10:24:54+00:00 app[worker.1]:     
2012-09-20T10:24:54+00:00 app[worker.1]:     irc.IRCClient.lineReceived(self, line)
2012-09-20T10:24:54+00:00 app[worker.1]: --- <exception caught here> ---
2012-09-20T10:24:54+00:00 app[worker.1]:     why = self.lineReceived(line)
2012-09-20T10:24:54+00:00 app[worker.1]:     self.handleCommand(command, prefix, params)
2012-09-20T10:24:54+00:00 app[worker.1]:     'reply_to': nick(user) if channel == self.nickname else channel,
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2465, in handleCommand
2012-09-20T10:24:54+00:00 app[worker.1]:     method(prefix, params)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 1937, in irc_PRIVMSG
2012-09-20T10:24:54+00:00 app[worker.1]:     self.privmsg(user, channel, message)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/core.py", line 239, in privmsg
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/core.py", line 191, in emit_new
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/events.py", line 57, in post_event
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/core.py", line 101, in post_event
2012-09-20T10:24:54+00:00 app[worker.1]:     self.handle_event(e)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/core.py", line 76, in <lambda>
2012-09-20T10:24:54+00:00 app[worker.1]:     self.bot.post_event(event)
2012-09-20T10:24:54+00:00 app[worker.1]:     self.events.post_event(event)
2012-09-20T10:24:54+00:00 app[worker.1]:     lambda e: self.plugins.broadcast('fire_hooks', (e,)))
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/plugin.py", line 121, in broadcast
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/plugins/linkinfo.py", line 86, in entry_point
2012-09-20T10:24:54+00:00 app[worker.1]:     f(self, event)
2012-09-20T10:24:54+00:00 app[worker.1]:     getattr(p, method)(*args)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/plugin.py", line 184, in fire_hooks
2012-09-20T10:24:54+00:00 app[worker.1]:     reply = self.scrape_html_title(url)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/csbot/plugins/linkinfo.py", line 107, in scrape_html_title
2012-09-20T10:24:54+00:00 app[worker.1]:     html = lxml.html.document_fromstring(r.text)
2012-09-20T10:24:54+00:00 app[worker.1]:     value = etree.fromstring(html, parser, **kw)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "lxml.etree.pyx", line 2969, in lxml.etree.fromstring (src/lxml/lxml.etree.c:61225)
2012-09-20T10:24:54+00:00 app[worker.1]:   File "/app/.heroku/venv/lib/python2.7/site-packages/lxml/html/__init__.py", line 563, in document_fromstring
2012-09-20T10:24:54+00:00 app[worker.1]:     
2012-09-20T10:24:54+00:00 app[worker.1]:   File "parser.pxi", line 1585, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:90542)
2012-09-20T10:24:54+00:00 app[worker.1]:     
2012-09-20T10:24:54+00:00 app[worker.1]: exceptions.ValueError: Unicode strings with encoding declaration are not supported.
```
