### PR TITLE
Refactor mongodb support to a plugin, where it belongs

### DIFF
--- a/csbot.example.cfg
+++ b/csbot.example.cfg
@@ -39,11 +39,14 @@
 # Default value: example
 #plugins =
 
+# Configuration for the MongoDB plugin
+[mongodb]
+
 # Default value: mongodb://localhost:27017
-#mongodb_uri =
+#uri =
 
 # Default value: csbot__
-#mongodb_prefix =
+#prefix =
 
 # This configuration is for the Example plugin
 [example]

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -4,7 +4,6 @@ import collections
 from twisted.words.protocols import irc
 from twisted.internet import reactor, protocol
 from twisted.python import log
-import pymongo
 import configparser
 import straight.plugin
 
@@ -42,14 +41,11 @@ class Bot(SpecialPlugin):
         'plugins': ' '.join([
             'example',
         ]),
-        'mongodb_uri': 'mongodb://localhost:27017',
-        'mongodb_prefix': 'csbot__',
     }
 
     #: Environment variable fallbacks
     CONFIG_ENVVARS = {
         'password': ['IRC_PASS'],
-        'mongodb_uri': ['MONGOLAB_URI', 'MONGODB_URI'],
     }
 
     #: Dictionary containing available plugins for loading, using
@@ -65,11 +61,6 @@ class Bot(SpecialPlugin):
                                                      allow_no_value=True)
         if config is not None:
             self.config_root.read_file(config)
-
-        # Make mongodb connection
-        self.log.info('connecting to mongodb: ' +
-                      self.config_get('mongodb_uri'))
-        self.mongodb = pymongo.Connection(self.config_get('mongodb_uri'))
 
         # Plugin management
         self.plugins = PluginManager([self], self.available_plugins,

--- a/csbot/plugin.py
+++ b/csbot/plugin.py
@@ -303,14 +303,6 @@ class Plugin(object):
         else:
             return self.config.getboolean(key)
 
-    @property
-    def db(self):
-        """Get a MongoDB database for the plugin, based on the plugin name."""
-        if self._db is None:
-            self._db = self.bot.mongodb[self.bot.config_get('mongodb_prefix') +
-                                        self.plugin_name()]
-        return self._db
-
 
 class SpecialPlugin(Plugin):
     """A special plugin with a special name that expects to be handled

--- a/csbot/plugins/mongodb.py
+++ b/csbot/plugins/mongodb.py
@@ -1,0 +1,39 @@
+import pymongo
+
+from csbot.plugin import Plugin
+
+
+class MongoDB(Plugin):
+    """A plugin that provides access to a MongoDB server via pymongo.
+    """
+    CONFIG_DEFAULTS = {
+        'uri': 'mongodb://localhost:27017',
+        'prefix': 'csbot__',
+    }
+
+    CONFIG_ENVVARS = {
+        'uri': ['MONGOLAB_URI', 'MONGODB_URI'],
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(MongoDB, self).__init__(*args, **kwargs)
+        self.log.info('connecting to mongodb: ' + self.config_get('uri'))
+        self.connection = pymongo.Connection(self.config_get('uri'))
+
+    def get_db(self, name):
+        """Get a named database.
+
+        A plugin depending on having access to MongoDB should firstly make sure
+        it states the dependency, and secondly grab references to any databases
+        it needs.  For example::
+
+            class MyPlugin(Plugin):
+                PLUGIN_DEPENDS = ['mongodb']
+
+                @Plugin.integrate_with('mongodb')
+                def _get_db(self, mongodb):
+                    self.db = mongodb.get_db(self.plugin_name())
+        """
+        dbname = self.config_get('prefix') + name
+        self.log.debug('creating database reference: ' + dbname)
+        return self.connection[dbname]


### PR DESCRIPTION
It's essential to move the MongoDB support out of the `Bot` class and into a plugin so that unit tests can run in an environment without a MongoDB server.  Unfortunately, this has some impact on other plugins: they can no longer assume `self.db` exists.

The docstring on the `get_db()` method gives an example of code for a plugin that requires a MongoDB database, using the plugin dependency and integration mechanisms.

Admittedly, this looks a little like boilerplate, which I like to avoid.  It might be possible to implement a layer of evil magic mechanisms so that plugins can provide easy access for things like this to other plugins, however I think it's already difficult enough to follow the actual thread of execution.

As it is, a plugin's database setup probably consists of more than getting a database reference: it'll probably want to get references to some collections, maybe create some indexes, maybe add some initial data.  In this case, the `@Plugin.integrate_with('mongodb')`-decorated method gives an excellent place to do this.
