### PR TITLE
Limit the size of responses linkinfo handles (fixes #91)

### DIFF
--- a/csbot/util.py
+++ b/csbot/util.py
@@ -79,15 +79,20 @@ def parse_arguments(raw):
     return list(lex)
 
 
-def simple_http_get(url):
+def simple_http_get(url, stream=False):
     """A deliberately dumb wrapper around :func:`requests.get`.
 
     This should be used for the vast majority of HTTP GET requests.  It turns
     off SSL certificate verification and sets a non-default User-Agent, thereby
     succeeding at most "just get the content" requests.
+
+    *stream* controls the "streaming mode" of the HTTP client, i.e. deferring
+    the acquisition of the response body.  Use this if you need to impose a
+    maximum size or process a large response.  *The entire content must be
+    consumed or ``response.close()`` must be called.*
     """
     headers = {'User-Agent': 'csbot/0.1'}
-    return requests.get(url, verify=False, headers=headers)
+    return requests.get(url, verify=False, headers=headers, stream=stream)
 
 
 def pairwise(iterable):


### PR DESCRIPTION
* Use streaming mode to prevent immediately fetching response body.
* Check Content-Length header against configurable limit.
* Only process a single chunk (of the limit size), just in case the
  Content-Length header is absent on a massive response.
* Wrap everything in ``contextlib.closing`` to prevent leaking connections.