### PR TITLE
Fix imgur tests by adding extra responses call

### DIFF
--- a/csbot/test/fixtures/imgur_credits.json
+++ b/csbot/test/fixtures/imgur_credits.json
@@ -1,0 +1,1 @@
+{"data":{"UserLimit":500,"UserRemaining":500,"UserReset":1475252872,"ClientLimit":12500,"ClientRemaining":12500},"success":true,"status":200}


### PR DESCRIPTION
imgurpython 1.1.3+ ([commit](https://github.com/Imgur/imgurpython/commit/6635a698531df9da9f4fbf93181273b3fd1b5062)) calls out to https://api.imgur.com/3/credits to get
its initial ratelimit settings. Therefore when the test object was
initialised (calling imgurpython \_\_init__), things broke.

Mocking that call fixes the issue, and I've also modified the tests a
bit to use @responses.activate decorator (like the xkcd plugin) rather
than creating a new responses object for each function.