### PR TITLE
Add tests for whois plugin

### DIFF
--- a/csbot/plugins/mongodb.py
+++ b/csbot/plugins/mongodb.py
@@ -1,4 +1,5 @@
 import pymongo
+import mongomock
 
 from csbot.plugin import Plugin
 
@@ -8,6 +9,7 @@ class MongoDB(Plugin):
     """
     CONFIG_DEFAULTS = {
         'uri': 'mongodb://localhost:27017/csbot',
+        'mode': 'uri',
     }
 
     CONFIG_ENVVARS = {
@@ -17,8 +19,16 @@ class MongoDB(Plugin):
     def __init__(self, *args, **kwargs):
         super(MongoDB, self).__init__(*args, **kwargs)
         self.log.info('connecting to mongodb: ' + self.config_get('uri'))
-        self.client = pymongo.MongoClient(self.config_get('uri'))
-        self.db = self.client.get_default_database()
+
+        if self.config_get('mode') == 'uri':
+            self.client = pymongo.MongoClient(self.config_get('uri'))
+            self.db = self.client.get_default_database()
+        elif self.config_get('mode') == 'mock':
+            self.log.info('using mock instead')
+            self.client = mongomock.MongoClient()
+            self.db = self.client.db
+        else:
+            raise ValueError('Expected a mode of either "uri" or "mock"')
 
     def provide(self, plugin_name, collection):
         """Get a MongoDB collection for ``{plugin_name}__{collection}``."""

--- a/csbot/plugins/whois.py
+++ b/csbot/plugins/whois.py
@@ -10,30 +10,44 @@ class Whois(Plugin):
 
     whoisdb = Plugin.use('mongodb', collection='whois')
 
+    def whois_lookup(self, nick, channel, db=None):
+        """Performs a whois lookup for a nick on a specific channel"""
+        db = db or self.whoisdb
+
+        ident = self.identify_user(nick, channel)
+        user = db.find_one(ident)
+
+        if user is None:
+            return None
+        else:
+            return user['data']
+
+    def whois_set(self, nick, channel, whois_str, db=None):
+        db = db or self.whoisdb
+
+        ident = self.identify_user(nick, channel)
+        db.remove(ident)
+
+        ident['data'] = whois_str
+        db.insert(ident)
+
     @Plugin.command('whois', help=('whois [nick]: show whois data for'
                                    ' a nick, or for yourself if omitted'))
     def whois(self, e):
         """Look up a user by nick, and return what data they have set for
         themselves (or an error message if there is no data)"""
-
         nick_ = e['data'] or nick(e['user'])
-        ident = self.identify_user(nick_, e['channel'])
-        user = self.whoisdb.find_one(ident)
+        res = self.whois_lookup(nick_, e['channel'])
 
-        if user is None:
+        if res is None:
             e.reply('No data for {}'.format(nick_))
         else:
-            e.reply('{}: {}'.format(nick_, user['data']))
+            e.reply('{}: {}'.format(nick_, str(res)))
 
     @Plugin.command('whois.set')
     def set(self, e):
         """Allow a user to associate data with themselves for this channel."""
-
-        ident = self.identify_user(nick(e['user']), e['channel'])
-        self.whoisdb.remove(ident)
-
-        ident['data'] = e['data']
-        self.whoisdb.insert(ident)
+        self.whois_set(nick(e['user']), e['channel'], e['data'])
 
     def identify_user(self, nick, channel):
         """Identify a user: by account if authed, if not, by nick. Produces a dict

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -1,0 +1,34 @@
+from csbot.test import BotTestCase, run_client
+from mongomock import MongoClient
+
+class TestWhoisPlugin(BotTestCase):
+    CONFIG = """\
+    [@bot]
+    plugins = mongodb usertrack whois
+    """
+
+    PLUGINS = ['whois']
+
+    def _assert_whois(self, nick, channel, whois_data):
+        assert self.whois.whoisdb.find_one({'nick': nick, 'channel': channel})['data'] == whois_data
+
+    def _recv_privmsg(self, name, channel, msg):
+        yield from self.client.line_received(':{} PRIVMSG {} :{}'.format(name, channel, msg))
+
+    def setUp(self):
+        super().setUp()
+        collection = MongoClient().db.collection
+        self.whois.whoisdb = collection
+
+    @run_client
+    def test_whois_set_singlechannel(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#channel', '!whois.set test')
+        self._assert_whois('Nick', '#channel', 'test')
+
+    @run_client
+    def test_whois_set_multichannel(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#channel1', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#channel2', '!whois.set test2')
+
+        self._assert_whois('Nick', '#channel1', 'test1')
+        self._assert_whois('Nick', '#channel2', 'test2')

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -24,21 +24,21 @@ class TestWhoisPlugin(BotTestCase):
         assert self.whois.whois_lookup('this_nick_doesnt_exist', '#anyChannel') is None
 
     def test_whois_insert(self):
-        self.whois.whois_set('nick1', '#channel1', 'test data')
-        assert self.whois.whois_lookup('nick1', '#channel1') == 'test data'
+        self.whois.whois_set('nick1', '#First', 'test data')
+        assert self.whois.whois_lookup('nick1', '#First') == 'test data'
         assert self.whois.whois_lookup('nick1', '#otherChannel') is None
 
     def test_whois_multi_user(self):
-        self.whois.whois_set('nick1', '#channel1', 'test1')
-        self.whois.whois_set('nick2', '#channel1', 'test2')
-        assert self.whois.whois_lookup('nick1', '#channel1') == 'test1'
-        assert self.whois.whois_lookup('nick2', '#channel1') == 'test2'
+        self.whois.whois_set('nick1', '#First', 'test1')
+        self.whois.whois_set('nick2', '#First', 'test2')
+        assert self.whois.whois_lookup('nick1', '#First') == 'test1'
+        assert self.whois.whois_lookup('nick2', '#First') == 'test2'
 
     def test_whois_multi_channel(self):
-        self.whois.whois_set('nick1', '#channel1', 'test data1')
-        self.whois.whois_set('nick1', '#channel2', 'test data2')
-        assert self.whois.whois_lookup('nick1', '#channel1') == 'test data1'
-        assert self.whois.whois_lookup('nick1', '#channel2') == 'test data2'
+        self.whois.whois_set('nick1', '#First', 'test data1')
+        self.whois.whois_set('nick1', '#Second', 'test data2')
+        assert self.whois.whois_lookup('nick1', '#First') == 'test data1'
+        assert self.whois.whois_lookup('nick1', '#Second') == 'test data2'
 
     @run_client
     def test_client_set_single_channel(self):
@@ -47,8 +47,31 @@ class TestWhoisPlugin(BotTestCase):
 
     @run_client
     def test_client_set_multi_channel(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#channel1', '!whois.set test1')
-        yield from self._recv_privmsg('Nick!~user@host', '#channel2', '!whois.set test2')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois.set test2')
 
-        self._assert_whois('Nick', '#channel1', 'test1')
-        self._assert_whois('Nick', '#channel2', 'test2')
+        self._assert_whois('Nick', '#First', 'test1')
+        self._assert_whois('Nick', '#Second', 'test2')
+
+    @run_client
+    def test_client_reply_whois_after_set(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
+
+    @run_client
+    def test_client_reply_whois_different_channel(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+
+    @run_client
+    def test_client_reply_whois_multiple_users_channels(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois.set test2')
+
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
+
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test2'))

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -1,65 +1,83 @@
+import functools
+
+import mongomock
+
 from csbot.test import BotTestCase, run_client
-from mongomock import MongoClient
+
+
+def failsafe(f):
+    """forces the test to fail if not using a mock
+    this prevents the tests from accidentally polluting a real database in the event of failure"""
+    @functools.wraps(f)
+    def decorator(self, *args, **kwargs):
+        assert isinstance(self.whois.whoisdb,
+                          mongomock.Collection), 'Not mocking MongoDB -- may be writing to actual database (!) (aborted test)'
+        return f(self, *args, **kwargs)
+    return decorator
 
 class TestWhoisPlugin(BotTestCase):
     CONFIG = """\
     [@bot]
     plugins = mongodb usertrack whois
+
+    [mongodb]
+    mode = mock
     """
 
     PLUGINS = ['whois']
 
-    def _assert_whois(self, nick, channel, whois_data):
-        assert self.whois.whoisdb.find_one({'nick': nick, 'channel': channel})['data'] == whois_data
-
     def _recv_privmsg(self, name, channel, msg):
         yield from self.client.line_received(':{} PRIVMSG {} :{}'.format(name, channel, msg))
 
-    def setUp(self):
-        super().setUp()
-        collection = MongoClient().db.collection
-        self.whois.whoisdb = collection
-
+    @failsafe
     def test_whois_empty(self):
         assert self.whois.whois_lookup('this_nick_doesnt_exist', '#anyChannel') is None
 
+    @failsafe
     def test_whois_insert(self):
         self.whois.whois_set('Nick', '#First', 'test data')
         assert self.whois.whois_lookup('Nick', '#First') == 'test data'
 
+    @failsafe
     def test_whois_set_overwrite(self):
         self.whois.whois_set('Nick', '#First', 'test data')
         self.whois.whois_set('Nick', '#First', 'overwritten data')
         assert self.whois.whois_lookup('Nick', '#First') == 'overwritten data'
 
+    @failsafe
     def test_whois_multi_user(self):
         self.whois.whois_set('Nick', '#First', 'test1')
         self.whois.whois_set('OtherNick', '#First', 'test2')
         assert self.whois.whois_lookup('Nick', '#First') == 'test1'
         assert self.whois.whois_lookup('OtherNick', '#First') == 'test2'
 
+    @failsafe
     def test_whois_multi_channel(self):
         self.whois.whois_set('Nick', '#First', 'first data')
         self.whois.whois_set('Nick', '#Second', 'second data')
         assert self.whois.whois_lookup('Nick', '#First') == 'first data'
         assert self.whois.whois_lookup('Nick', '#Second') == 'second data'
 
+    @failsafe
     def test_whois_channel_specific(self):
         self.whois.whois_set('Nick', '#First', 'first data')
         assert self.whois.whois_lookup('Nick', '#AnyOtherChannel') is None
 
+    @failsafe
     @run_client
     def test_client_reply_whois_after_set(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
 
+    @failsafe
     @run_client
     def test_client_reply_whois_different_channel(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
+    @failsafe
     @run_client
     def test_client_reply_whois_multiple_users_channels(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
@@ -71,6 +89,7 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Other!~user@host', '#Second', '!whois Nick')
         self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test2'))
 
+    @failsafe
     @run_client
     def test_client_reply_whois_self(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -20,13 +20,33 @@ class TestWhoisPlugin(BotTestCase):
         collection = MongoClient().db.collection
         self.whois.whoisdb = collection
 
+    def test_whois_empty(self):
+        assert self.whois.whois_lookup('this_nick_doesnt_exist', '#anyChannel') is None
+
+    def test_whois_insert(self):
+        self.whois.whois_set('nick1', '#channel1', 'test data')
+        assert self.whois.whois_lookup('nick1', '#channel1') == 'test data'
+        assert self.whois.whois_lookup('nick1', '#otherChannel') is None
+
+    def test_whois_multi_user(self):
+        self.whois.whois_set('nick1', '#channel1', 'test1')
+        self.whois.whois_set('nick2', '#channel1', 'test2')
+        assert self.whois.whois_lookup('nick1', '#channel1') == 'test1'
+        assert self.whois.whois_lookup('nick2', '#channel1') == 'test2'
+
+    def test_whois_multi_channel(self):
+        self.whois.whois_set('nick1', '#channel1', 'test data1')
+        self.whois.whois_set('nick1', '#channel2', 'test data2')
+        assert self.whois.whois_lookup('nick1', '#channel1') == 'test data1'
+        assert self.whois.whois_lookup('nick1', '#channel2') == 'test data2'
+
     @run_client
-    def test_whois_set_singlechannel(self):
+    def test_client_set_single_channel(self):
         yield from self._recv_privmsg('Nick!~user@host', '#channel', '!whois.set test')
         self._assert_whois('Nick', '#channel', 'test')
 
     @run_client
-    def test_whois_set_multichannel(self):
+    def test_client_set_multi_channel(self):
         yield from self._recv_privmsg('Nick!~user@host', '#channel1', '!whois.set test1')
         yield from self._recv_privmsg('Nick!~user@host', '#channel2', '!whois.set test2')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ rollbar
 responses
 coverage>=4.0.3,<5.0.0
 python-coveralls>=2.6.0,<2.7.0
+mongomock
 
 # Requirements for documentation
 # (commented out to save build time)


### PR DESCRIPTION
Add unit and end-to-end integration tests for the `whois` plugin.

These include mocking of pymongo with `mongomock`, which would now be a requirement. These tests should be enough to act as specification for the module as well as ensure future changes (such as a `!whois.setdefault` command) don't break the current flow.

Currently it doesn't test against a *real* MongoDB instance, and so there's no continuity checks (i.e. there's no way of checking a change you make breaks/doesn't break a `!whois.set` that was already stored) but that seems over-the-top to include for now (although thanks to the decoupling in the first commit it should be fairly easy to save and load to a real MongoDB instance in some of the tests).