### PR TITLE
Add !whois.setdefault

### DIFF
--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -35,33 +35,68 @@ class TestWhoisPlugin(BotTestCase):
 
     @failsafe
     def test_whois_insert(self):
-        self.whois.whois_set('Nick', '#First', 'test data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='test data')
         assert self.whois.whois_lookup('Nick', '#First') == 'test data'
 
     @failsafe
+    def test_whois_unset(self):
+        self.whois.whois_set('Nick', channel='#First', whois_str='test data')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test data'
+        self.whois.whois_unset('Nick', '#First')
+        assert self.whois.whois_lookup('Nick', '#First') is None
+
+    @failsafe
     def test_whois_set_overwrite(self):
-        self.whois.whois_set('Nick', '#First', 'test data')
-        self.whois.whois_set('Nick', '#First', 'overwritten data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='test data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='overwritten data')
         assert self.whois.whois_lookup('Nick', '#First') == 'overwritten data'
 
     @failsafe
     def test_whois_multi_user(self):
-        self.whois.whois_set('Nick', '#First', 'test1')
-        self.whois.whois_set('OtherNick', '#First', 'test2')
+        self.whois.whois_set('Nick', channel='#First', whois_str='test1')
+        self.whois.whois_set('OtherNick', channel='#First', whois_str='test2')
         assert self.whois.whois_lookup('Nick', '#First') == 'test1'
         assert self.whois.whois_lookup('OtherNick', '#First') == 'test2'
 
     @failsafe
     def test_whois_multi_channel(self):
-        self.whois.whois_set('Nick', '#First', 'first data')
-        self.whois.whois_set('Nick', '#Second', 'second data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='first data')
+        self.whois.whois_set('Nick', channel='#Second', whois_str='second data')
         assert self.whois.whois_lookup('Nick', '#First') == 'first data'
         assert self.whois.whois_lookup('Nick', '#Second') == 'second data'
 
     @failsafe
     def test_whois_channel_specific(self):
-        self.whois.whois_set('Nick', '#First', 'first data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='first data')
         assert self.whois.whois_lookup('Nick', '#AnyOtherChannel') is None
+
+    @failsafe
+    def test_whois_setdefault(self):
+        self.whois.whois_set('Nick', 'test default data')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test default data'
+        assert self.whois.whois_lookup('Nick', '#Other') == 'test default data'
+        self.whois.whois_unset('Nick', '#First')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test default data'
+
+    @failsafe
+    def test_whois_channel_before_setdefault(self):
+        self.whois.whois_set('Nick', 'test default data')
+        self.whois.whois_set('Nick', channel='#First', whois_str='test first data')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test first data'
+        assert self.whois.whois_lookup('Nick', '#Other') == 'test default data'
+        self.whois.whois_unset('Nick', '#First')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test default data'
+
+    @failsafe
+    def test_whois_setdefault_unset(self):
+        self.whois.whois_set('Nick', 'test default data')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test default data'
+        assert self.whois.whois_lookup('Nick', '#Other') == 'test default data'
+        self.whois.whois_unset('Nick', '#First')
+        assert self.whois.whois_lookup('Nick', '#First') == 'test default data'
+        self.whois.whois_unset('Nick')
+        assert self.whois.whois_lookup('Nick', '#First') is None
+        assert self.whois.whois_lookup('Nick', '#Second') is None
 
     @failsafe
     @run_client
@@ -95,3 +130,37 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
+
+    @failsafe
+    @run_client
+    def test_client_reply_whois_setdefault_unset(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setdefault test data')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test data'))
+        yield from self._recv_privmsg('Other!~other@otherhost', '#Third', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test first')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test first'))
+        yield from self._recv_privmsg('Other!~other@otherhost', '#Second', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
+
+    @failsafe
+    @run_client
+    def test_client_reply_whois_setdefault_unset(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setdefault test data')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test data'))
+        yield from self._recv_privmsg('Other!~other@otherhost', '#Third', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.unsetdefault')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+        yield from self._recv_privmsg('Other!~other@otherhost', '#Third', '!whois Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Third', 'No data for Nick'))

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -133,7 +133,7 @@ class TestWhoisPlugin(BotTestCase):
 
     @failsafe
     @run_client
-    def test_client_reply_whois_setdefault_unset(self):
+    def test_client_reply_whois_setdefault_then_unset_channel(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setdefault test data')
 
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
@@ -146,11 +146,11 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test first'))
         yield from self._recv_privmsg('Other!~other@otherhost', '#Second', '!whois Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test data'))
 
     @failsafe
     @run_client
-    def test_client_reply_whois_setdefault_unset(self):
+    def test_client_reply_whois_setdefault_then_unsetdefault(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setdefault test data')
 
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')


### PR DESCRIPTION
Adds new commands: whois.setdefault, whois.unset and whois.unsetdefault along with tests for each.

This is one of those instances where having tests that operated on some pre-defined MongoDB instance with some old data in it good, to ensure a change doesn't break already-existing data for smallish changes that don't require a full database migration (like this)