### PR TITLE
Quote plugin

### DIFF
--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -27,48 +27,61 @@ class Quote(Plugin):
         """
         return self.quotedb.find_one({'quoteId': quoteId})
 
-    def format_quote_id(self, quote_id, long=False):
-        if long:
-            current = self.get_current_quote_id()
-            len_current = len(str(current))
+    def format_quote_id(self, quote_id, pad=False):
+        """Formats the quote_id as a string.
 
-            if current == -1:  # no quotes yet
-                return str(quote_id)
-            return str(quote_id).ljust(len_current)
-        else:
+        Can ask for a long-form version, which pads and aligns, or a short version:
+
+        >>> self.format_quote_id(3)
+        '3'
+        >>> self.format_quote_id(23, pad=True)
+        '23   '
+        """
+
+        if not pad:
             return str(quote_id)
+        else:
+            current = self.get_current_quote_id()
+
+            if current == -1:  # quote_id is the first quote
+                return str(quote_id)
+
+            length = len(str(current))
+            return '{:<{length}}'.format(quote_id, length=length)
 
     def format_quote(self, q, show_channel=False, show_id=True):
-        quoteId = self.format_quote_id(q['quoteId'], long=show_channel)
+        """ Formats a quote into a prettified string.
 
-        if show_channel:
+        >>> self.format_quote({'quoteId': 3})
+        "[3] <Alan> some silly quote..."
+
+        >>> self.format_quote({'quoteId': 3}, show_channel=True, show_id=False)
+        "[1  ] - #test - <Alan> silly quote"
+        """
+        quote_id_fmt = self.format_quote_id(q['quoteId'], pad=show_channel)
+
+        if show_channel and show_id:
+            fmt = '[{quoteId}] - {channel} - <{nick}> {message}'
+        elif show_channel and not show_id:
             fmt = '{channel} - <{nick}> {message}'
-            if show_id:
-                fmt = '[{quoteId}] - ' + fmt
+        elif not show_channel and show_id:
+            fmt = '[{quoteId}] <{nick}> {message}'
         else:
             fmt = '<{nick}> {message}'
-            if show_id:
-                fmt = '[{quoteId}] ' + fmt
 
-        return fmt.format(quoteId=quoteId, channel=q['channel'], nick=q['nick'], message=q['message'])
-
-    def paste_quotes(self, quotes):
-        paste_content = '\n'.join(self.format_quote(q, show_channel=True) for q in quotes[:100])
-        if len(quotes) > 100:
-            paste_content = 'Latest 100 quotes:\n' + paste_content
-
-        req = requests.post('http://dpaste.com/api/v2/', {'content': paste_content})
-        if req:
-            return req.content.decode('utf-8').strip()
+        return fmt.format(quoteId=quote_id_fmt, channel=q['channel'], nick=q['nick'], message=q['message'])
 
     def set_current_quote_id(self, id):
-        """sets the last quote id
+        """ Sets the last quote id
+
+        We keep track of the latest quote ID (they're sequential) in the database
+        To update it we remove the old one and insert a new record.
         """
         self.quotedb.remove({'header': 'currentQuoteId'})
         self.quotedb.insert({'header': 'currentQuoteId', 'maxQuoteId': id})
 
     def get_current_quote_id(self):
-        """gets the current maximum quote id
+        """ Gets the current maximum quote ID
         """
         id_dict = self.quotedb.find_one({'header': 'currentQuoteId'})
         if id_dict is not None:
@@ -79,9 +92,11 @@ class Quote(Plugin):
         return current_id
 
     def insert_quote(self, udict):
-        """inserts a {'user': user, 'channel': channel, 'message': msg}
-           or        {'account': accnt, 'channel': channel, 'message': msg}
-        quote into the database
+        """ Remember a quote by storing it in the database
+
+        Inserts a {'user': user, 'channel': channel, 'message': msg}
+        or        {'account': accnt, 'channel': channel, 'message': msg}
+        quote into the persistent storage.
         """
 
         id = self.get_current_quote_id()
@@ -92,7 +107,9 @@ class Quote(Plugin):
         return sId
 
     def message_matches(self, msg, pattern=None):
-        """returns True if `msg` matches `pattern`
+        """ Check whether the given message matches the given pattern
+
+        If there is no pattern, it is treated as a wildcard and all messages match.
         """
         if pattern is None:
             return True
@@ -100,9 +117,7 @@ class Quote(Plugin):
         return re.search(pattern, msg) is not None
 
     def quote_set(self, nick, channel, pattern=None):
-        """writes the last quote that matches `pattern` to the database
-        and returns its id
-        returns None if no match found
+        """ Insert the last matching quote from a user on a particular channel into the quotes database.
         """
         user = self.identify_user(nick, channel)
 
@@ -114,9 +129,72 @@ class Quote(Plugin):
 
         return None
 
+    @Plugin.command('remember', help=("remember <nick> [<pattern>]: adds last quote that matches <pattern> to the database"))
+    def remember(self, e):
+        """ Remembers the last matching quote from a user
+        """
+        data = e['data'].strip()
+        channel = e['channel']
+        user_nick = nick(e['user'])
+
+        m = re.fullmatch(r'(?P<nick>\S+)', data)
+        if m:
+            print('fullmatch nick!')
+            return self.remember_quote(e, user_nick, m.group('nick'), channel, None)
+
+        m = re.fullmatch(r'(?P<nick>\S+)\s+(?P<pattern>.+)', data)
+        if m:
+            print('fullmatch pat')
+            return self.remember_quote(e, user_nick, m.group('nick'), channel, m.group('pattern').strip())
+
+        e.reply('Invalid nick or pattern')
+
+    def remember_quote(self, e, user, nick, channel, pattern):
+        res = self.quote_set(nick, channel, pattern)
+        if res is None:
+            if pattern is not None:
+                e.reply(f'No data for {nick} found matching "{pattern}"')
+            else:
+                e.reply( f'No data for {nick}')
+        else:
+            self.bot.reply(user, 'remembered "{}"'.format(self.format_quote(res, show_id=False)))
+
+    @Plugin.command('quote', help=("quote [<nick> [<pattern>]]: looks up quotes from <nick>"
+                                   " (optionally only those matching <pattern>)"))
+    def quote(self, e):
+        """ Lookup quotes for the given channel/nick and outputs one
+        """
+        data = e['data']
+        channel = e['channel']
+
+        if data.strip() == '':
+            return e.reply(self.find_a_quote('*', channel, None))
+
+        m = re.fullmatch(r'(?P<nick>\S+)', data)
+        if m:
+            return e.reply(self.find_a_quote(m.group('nick'), channel, None))
+
+        m = re.fullmatch(r'(?P<nick>\S+)\s+(?P<pattern>.+)', data)
+        if m:
+            return e.reply(self.find_a_quote(m.group('nick'), channel, m.group('pattern')))
+
+    def find_a_quote(self, nick, channel, pattern):
+        """ Finds a random matching quote from a user on a specific channel
+
+        Returns the formatted quote string
+        """
+        res = list(self.find_quotes(nick, channel, pattern))
+        if not res:
+            if nick == '*':
+                return 'No data'
+            else:
+                return 'No data for {}'.format(nick)
+        else:
+            out = random.choice(res)
+            return self.format_quote(out, show_channel=False)
+
     def find_quotes(self, nick, channel, pattern=None):
-        """finds and yields all quotes from nick
-        on channel `channel` (optionally matching on `pattern`)
+        """ Finds and yields all quotes for a particular nick on a given channel
         """
         if nick == '*':
             user = {'channel': channel}
@@ -127,7 +205,47 @@ class Quote(Plugin):
             if self.message_matches(quote['message'], pattern=pattern):
                 yield quote
 
+    @Plugin.command('quote.list', help=("quote.list [<pattern>]: looks up all quotes on the channel"))
+    def quote_list(self, e):
+        """ Look for all quotes that match a given pattern in a channel
+
+        This action pastes multiple lines and so needs authorization.
+        """
+        channel = e['channel']
+        nick_ = nick(e['user'])
+
+        if not self.bot.plugins['auth'].check_or_error(e, 'quote', channel):
+            return
+
+        if channel == self.bot.nick:
+            # first argument must be a channel
+            data = e['data'].split(maxsplit=1)
+
+            # TODO: use assignment expressions here when they come out
+            # https://www.python.org/dev/peps/pep-0572/
+            just_channel = re.fullmatch(r'(?P<channel>\S+)', data)
+            channel_and_pat = re.fullmatch(r'(?P<channel>\S+)\s+(?P<pattern>.+)', data)
+            if just_channel:
+                return self.reply_with_summary(nick_, just_channel.group('channel'), None)
+            elif channel_and_pat:
+                return self.reply_with_summary(nick_, channel_and_pat.group('channel'), channel_and_pat.group('pattern'))
+
+            return e.reply('Invalid command. Syntax in privmsg is !quote.list <channel> [<pattern>]')
+        else:
+            pattern = e['data']
+            return self.reply_with_summary(nick_, channel, pattern)
+
+    def reply_with_summary(self, to, channel, pattern):
+        """ Helper to list all quotes for a summary paste.
+        """
+        for line in self.quote_summary(channel, pattern=pattern):
+            self.bot.reply(to, line)
+
     def quote_summary(self, channel, pattern=None, dpaste=True):
+        """ Search through all quotes for a channel and optionally paste a list of them
+
+        Returns the last 5 matching quotes only, the remainder are added to a pastebin.
+        """
         quotes = list(self.quotedb.find({'channel': channel}, sort=[('quoteId', pymongo.DESCENDING)]))
         if not quotes:
             if pattern:
@@ -140,98 +258,25 @@ class Quote(Plugin):
         for q in quotes[:5]:
             yield self.format_quote(q, show_channel=True)
 
-        if dpaste:
-            if len(quotes) > 5:
-                paste_link = self.paste_quotes(quotes)
-                if paste_link:
-                    yield 'Full summary at: {}'.format(paste_link)
-
-    @Plugin.command('remember', help=("remember <nick> [<pattern>]: adds last quote that matches <pattern> to the database"))
-    def remember(self, e):
-        """Remembers something said
-        """
-        data = e['data'].split(maxsplit=1)
-        channel = e['channel']
-        user_nick = nick(e['user'])
-
-        if len(data) < 1:
-            return e.reply('Expected more arguments, see !help remember')
-
-        nick_ = data[0].strip()
-
-        if len(data) == 1:
-            pattern = ''
-        else:
-            pattern = data[1].strip()
-
-        res = self.quote_set(nick_, channel, pattern)
-
-        if res is None:
-            if pattern:
-                e.reply('No data for {} found matching "{}"'.format(nick_, pattern))
+        if dpaste and len(quotes) > 5:
+            paste_link = self.paste_quotes(quotes)
+            if paste_link:
+                yield 'Full summary at: {}'.format(paste_link)
             else:
-                e.reply('No data for {}'.format(nick_))
-        else:
-            self.bot.reply(user_nick, 'remembered "{}"'.format(self.format_quote(res, show_channel=False, show_id=False)))
+                self.log.warn(f'Failed to upload full summary: {paste_link}')
 
-    @Plugin.command('quote', help=("quote [<nick> [<pattern>]]: looks up quotes from <nick>"
-                                    " (optionally only those matching <pattern>)"))
-    def quote(self, e):
-        """ Lookup quotes for the given channel/nick and outputs one
+    def paste_quotes(self, quotes):
+        """ Pastebins a the last 100 quotes and returns the url
         """
-        data = e['data'].split(maxsplit=1)
-        channel = e['channel']
+        paste_content = '\n'.join(self.format_quote(q, show_channel=True) for q in quotes[:100])
+        if len(quotes) > 100:
+            paste_content = 'Latest 100 quotes:\n' + paste_content
 
-        if len(data) < 1:
-            nick_ = '*'
-        else:
-            nick_ = data[0].strip()
+        req = requests.post('http://dpaste.com/api/v2/', {'content': paste_content})
+        if req:
+            return req.content.decode('utf-8').strip()
 
-        if len(data) <= 1:
-            pattern = ''
-        else:
-            pattern = data[1].strip()
-
-        res = list(self.find_quotes(nick_, channel, pattern))
-        if not res:
-            if nick_ == '*':
-                e.reply('No data')
-            else:
-                e.reply('No data for {}'.format(nick_))
-        else:
-            out = random.choice(res)
-            e.reply(self.format_quote(out, show_channel=False))
-
-    @Plugin.command('quote.list', help=("quote.list [<pattern>]: looks up all quotes on the channel"))
-    def quoteslist(self, e):
-        """Lookup the nick given
-        """
-        channel = e['channel']
-        nick_ = nick(e['user'])
-
-        if not self.bot.plugins['auth'].check_or_error(e, 'quote', channel):
-            return
-
-        if channel == self.bot.nick:
-            # first argument must be a channel
-            data = e['data'].split(maxsplit=1)
-            if len(data) < 1:
-                return e.reply('No channel supplied. Syntax for privmsg version is !quote.list <channel> [<pattern>]')
-
-            quote_channel = data[0]
-
-            if len(data) == 1:
-                pattern = None
-            else:
-                pattern = data[1]
-
-            for line in self.quote_summary(quote_channel, pattern=pattern):
-                e.reply(line)
-        else:
-            pattern = e['data']
-
-            for line in self.quote_summary(channel, pattern=pattern):
-                self.bot.reply(nick_, line)
+        return req  # return the failed request to handle error later
 
     @Plugin.command('quote.remove', help=("quote.remove <id> [, <id>]*: removes quotes from the database"))
     def quotes_remove(self, e):
@@ -248,7 +293,6 @@ class Quote(Plugin):
 
         ids = [qId.strip() for qId in data]
         invalid_ids = []
-        quotes = []
         for id in ids:
             if id == '-1':
                 # special case -1, to be the last
@@ -256,23 +300,29 @@ class Quote(Plugin):
                 if _id:
                     id = _id['quoteId']
 
-            try:
-                id = int(id)
-            except ValueError:
+            if not self.remove_quote(id):
                 invalid_ids.append(id)
-            else:
-                q = self.quote_from_id(id)
-                if q:
-                    quotes.append(q)
-                else:
-                    invalid_ids.append(id)
 
         if invalid_ids:
             str_invalid_ids = ', '.join(str(id) for id in invalid_ids)
-            return e.reply('No quotes with id(s) {ids} (request aborted)'.format(ids=str_invalid_ids))
+            return e.reply('Could not remove quotes with IDs: {ids} (error: quote does not exist)'.format(ids=str_invalid_ids))
+
+    def remove_quote(self, quoteId):
+        """ Remove a given quote from the database
+
+        Returns False if the quoteId is invalid or does not exist.
+        """
+
+        try:
+            id = int(quoteId)
+        except ValueError:
+            return False
         else:
-            for q in quotes:
-                self.quotedb.remove(q)
+            q = self.quote_from_id(id)
+            if not q:
+                return False
+
+            self.quotedb.remove(q)
 
     @Plugin.hook('core.message.privmsg')
     def log_privmsgs(self, e):

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -1,0 +1,265 @@
+import re
+import functools
+import collections
+
+import pymongo
+import requests
+
+from csbot.plugin import Plugin
+from csbot.util import nick, subdict
+
+class Quote(Plugin):
+    """Attach channel specific quotes to a user
+    """
+
+    PLUGIN_DEPENDS = ['usertrack']
+
+    quotedb = Plugin.use('mongodb', collection='quotedb')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.channel_logs = collections.defaultdict(functools.partial(collections.deque, maxlen=100))
+
+    def quote_from_id(self, quoteId):
+        """gets a quote with some `quoteId` from the database
+        returns None if no such quote exists
+        """
+        return self.quotedb.find_one({'quoteId': quoteId})
+
+    def format_quote(self, q):
+        current = self.get_current_quote_id()
+        len_current = len(str(current))
+        quoteId = str(q['quoteId']).ljust(len_current)
+        return '{quoteId} - {channel} - <{nick}> {message}'.format(quoteId=quoteId,
+                                                                   channel=q['channel'],
+                                                                   nick=q['nick'],
+                                                                   message=q['message'])
+
+    def paste_quotes(self, quotes):
+        if len(quotes) > 5:
+            paste_content = '\n'.join(self.format_quote(q) for q in quotes)
+            req = requests.post('http://dpaste.com/api/v2/', {'content': paste_content})
+            if req:
+                return req.content.decode('utf-8').strip()
+
+    def set_current_quote_id(self, id):
+        """sets the last quote id
+        """
+        self.quotedb.remove({'header': 'currentQuoteId'})
+        self.quotedb.insert({'header': 'currentQuoteId', 'maxQuoteId': id})
+
+    def get_current_quote_id(self):
+        """gets the current maximum quote id
+        """
+        id_dict = self.quotedb.find_one({'header': 'currentQuoteId'})
+        if id_dict is not None:
+            current_id = id_dict['maxQuoteId']
+        else:
+            current_id = -1
+
+        return current_id
+
+    def insert_quote(self, udict):
+        """inserts a {'user': user, 'channel': channel, 'message': msg}
+           or        {'account': accnt, 'channel': channel, 'message': msg}
+        quote into the database
+        """
+
+        id = self.get_current_quote_id()
+        sId = id + 1
+        udict['quoteId'] = sId
+        self.quotedb.insert(udict)
+        self.set_current_quote_id(sId)
+        return sId
+
+    def message_matches(self, msg, pattern=None):
+        """returns True if `msg` matches `pattern`
+        """
+        if pattern is None:
+            return True
+
+        return re.search(pattern, msg) is not None
+
+    def quote_set(self, nick, channel, pattern=None):
+        """writes the last quote that matches `pattern` to the database
+        and returns its id
+        returns None if no match found
+        """
+        user = self.identify_user(nick, channel)
+
+        for udict in self.channel_logs[channel]:
+            if subdict(user, udict):
+                if self.message_matches(udict['message'], pattern=pattern):
+                    return self.insert_quote(udict)
+
+        return None
+
+    def find_quotes(self, nick, channel, pattern=None):
+        """finds and yields all quotes from nick
+        on channel `channel` (optionally matching on `pattern`)
+        """
+        user = self.identify_user(nick, channel)
+        for quote in self.quotedb.find(user, sort=[('quoteId', pymongo.ASCENDING)]):
+            if self.message_matches(quote['message'], pattern=pattern):
+                yield quote
+
+    def quote_summary(self, channel, pattern=None, dpaste=True):
+        quotes = list(self.quotedb.find({'channel': channel}, sort=[('quoteId', pymongo.ASCENDING)]))
+        if not quotes:
+            if pattern:
+                yield 'Cannot find quotes for channel {} that match "{}"'.format(channel, pattern)
+            else:
+                yield 'Cannot find quotes for channel {}'.format(channel)
+
+            return
+
+        for q in quotes[:5]:
+            yield self.format_quote(q)
+
+        if dpaste:
+            paste_link = self.paste_quotes(quotes)
+            if paste_link:
+                yield 'Full summary at: {}'.format(paste_link)
+
+    @Plugin.command('quote', help=("quote <nick> [<pattern>]: adds last quote that matches <pattern> to the database"))
+    def quote(self, e):
+        """Lookup the nick given
+        """
+        data = e['data'].split(maxsplit=1)
+
+        if len(data) < 1:
+            return e.reply('Expected more arguments, see !help quote')
+
+        nick_ = data[0].strip()
+
+        if len(data) == 1:
+            pattern = ''
+        else:
+            pattern = data[1].strip()
+
+        res = self.quote_set(nick_, e['channel'], pattern)
+
+        if res is None:
+            if pattern:
+                e.reply('Found no messages from {} found matching "{}"'.format(nick_, pattern))
+            else:
+                e.reply('Unknown nick {}'.format(nick_))
+
+    @Plugin.command('quotes', help=("quote <nick> [<pattern>]: looks up quotes from <nick>"
+                                    " (optionally only those matching <pattern>)"))
+    def quotes(self, e):
+        """Lookup the nick given
+        """
+        data = e['data'].split(maxsplit=1)
+        channel = e['channel']
+
+        if len(data) < 1:
+            return e.reply('Expected arguments, see !help quote')
+
+        nick_ = data[0].strip()
+
+        if len(data) == 1:
+            pattern = ''
+        else:
+            pattern = data[1].strip()
+
+        res = self.find_quotes(nick_, channel, pattern)
+        out = next(res, None)
+        if out is None:
+            e.reply('No quotes recorded for {}'.format(nick_))
+        else:
+            e.reply('<{}> {}'.format(out['nick'], out['message']))
+
+
+    @Plugin.command('quotes.list', help=("quotes.list [<pattern>]: looks up all quotes on the channel"))
+    def quoteslist(self, e):
+        """Lookup the nick given
+        """
+        channel = e['channel']
+        nick_ = nick(e['user'])
+
+        if nick_ == channel:
+            # first argument must be a channel
+            data = e['data'].split(maxsplit=1)
+            if len(data) < 1:
+                return e.reply('Expected at least <channel> argument in PRIVMSGs, see !help quotes.list')
+
+            quote_channel = data[0]
+
+            if len(data) == 1:
+                pattern = None
+            else:
+                pattern = data[1]
+
+            for line in self.quote_summary(quote_channel, pattern=pattern):
+                e.reply(line)
+        else:
+            pattern = e['data']
+
+            for line in self.quote_summary(channel, pattern=pattern):
+                self.bot.reply(nick_, line)
+
+    @Plugin.command('quotes.remove', help=("quotes.remove <id> [, <id>]*: removes quotes from the database"))
+    def quotes_remove(self, e):
+        """Lookup the given quotes and remove them from the database transcationally
+        """
+        data = e['data'].split(',')
+        channel = e['channel']
+
+        if len(data) < 1:
+            return e.reply('Expected at least 1 quoteID to remove.')
+
+        ids = [qId.strip() for qId in data]
+        invalid_ids = []
+        quotes = []
+        for id in ids:
+            if id == '-1':
+                # special case -1, to be the last
+                _id = self.quotedb.find_one({'channel': channel}, sort=[('quoteId', pymongo.DESCENDING)])
+                if _id:
+                    id = _id['quoteId']
+
+            try:
+                id = int(id)
+            except ValueError:
+                invalid_ids.append(id)
+            else:
+                q = self.quote_from_id(id)
+                if q:
+                    quotes.append(q)
+                else:
+                    invalid_ids.append(id)
+
+        if invalid_ids:
+            str_invalid_ids = ', '.join(str(id) for id in invalid_ids)
+            return e.reply('Cannot find quotes with ids {ids} (request aborted)'.format(ids=str_invalid_ids))
+        else:
+            for q in quotes:
+                self.quotedb.remove(q)
+
+    @Plugin.hook('core.message.privmsg')
+    def log_privmsgs(self, e):
+        """Register privmsgs for a channel and stick them into the log for that channel
+        this is merely an in-memory deque, so won't survive across restarts/crashes
+        """
+        msg = e['message']
+
+        channel = e['channel']
+        user = nick(e['user'])
+        ident = self.identify_user(user, channel)
+        ident['message'] = msg
+        ident['nick'] = user  # even for auth'd user, save their nick
+        self.channel_logs[channel].appendleft(ident)
+
+    def identify_user(self, nick, channel):
+        """Identify a user: by account if authed, if not, by nick. Produces a dict
+        suitable for throwing at mongo."""
+
+        user = self.bot.plugins['usertrack'].get_user(nick)
+
+        if user['account'] is not None:
+            return {'account': user['account'],
+                    'channel': channel}
+        else:
+            return {'nick': nick,
+                    'channel': channel}

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -30,9 +30,9 @@ class Quote(Plugin):
     def format_quote(self, q, show_channel=False):
         current = self.get_current_quote_id()
         len_current = len(str(current))
-        quoteId = str(q['quoteId']).ljust(len_current)
-        fmt_channel = '({quoteId}) - {channel} - <{nick}> {message}'
-        fmt_nochannel = '({quoteId}) <{nick}> {message}'
+        quoteId = str(q['quoteId']) if not show_channel else str(q['quoteId']).ljust(len_current)
+        fmt_channel = '[{quoteId}] - {channel} - <{nick}> {message}'
+        fmt_nochannel = '[{quoteId}] <{nick}> {message}'
         fmt = fmt_channel if show_channel else fmt_nochannel
         return fmt.format(quoteId=quoteId, channel=q['channel'], nick=q['nick'], message=q['message'])
 

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -54,7 +54,6 @@ class Quote(Plugin):
 
         >>> self.format_quote({'quoteId': 3})
         "[3] <Alan> some silly quote..."
-
         >>> self.format_quote({'quoteId': 3}, show_channel=True, show_id=False)
         "[1  ] - #test - <Alan> silly quote"
         """

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -37,7 +37,7 @@ class Quote(Plugin):
         return fmt.format(quoteId=quoteId, channel=q['channel'], nick=q['nick'], message=q['message'])
 
     def paste_quotes(self, quotes):
-        paste_content = '\n'.join(self.format_quote(q) for q in quotes[:100])
+        paste_content = '\n'.join(self.format_quote(q, show_channel=True) for q in quotes[:100])
         if len(quotes) > 100:
             paste_content = 'Latest 100 quotes:\n' + paste_content
 
@@ -111,7 +111,7 @@ class Quote(Plugin):
                 yield quote
 
     def quote_summary(self, channel, pattern=None, dpaste=True):
-        quotes = list(self.quotedb.find({'channel': channel}, sort=[('quoteId', pymongo.ASCENDING)]))
+        quotes = list(self.quotedb.find({'channel': channel}, sort=[('quoteId', pymongo.DESCENDING)]))
         if not quotes:
             if pattern:
                 yield 'No quotes for channel {} that match "{}"'.format(channel, pattern)
@@ -191,7 +191,7 @@ class Quote(Plugin):
         if not self.bot.plugins['auth'].check_or_error(e, 'quote', channel):
             return
 
-        if nick_ == channel:
+        if channel == self.bot.nick:
             # first argument must be a channel
             data = e['data'].split(maxsplit=1)
             if len(data) < 1:
@@ -248,7 +248,7 @@ class Quote(Plugin):
 
         if invalid_ids:
             str_invalid_ids = ', '.join(str(id) for id in invalid_ids)
-            return e.reply('Cannot find quotes with ids {ids} (request aborted)'.format(ids=str_invalid_ids))
+            return e.reply('No quotes with id(s) {ids} (request aborted)'.format(ids=str_invalid_ids))
         else:
             for q in quotes:
                 self.quotedb.remove(q)

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -114,9 +114,9 @@ class Quote(Plugin):
         quotes = list(self.quotedb.find({'channel': channel}, sort=[('quoteId', pymongo.ASCENDING)]))
         if not quotes:
             if pattern:
-                yield 'Cannot find quotes for channel {} that match "{}"'.format(channel, pattern)
+                yield 'No quotes for channel {} that match "{}"'.format(channel, pattern)
             else:
-                yield 'Cannot find quotes for channel {}'.format(channel)
+                yield 'No quotes for channel {}'.format(channel)
 
             return
 
@@ -149,9 +149,9 @@ class Quote(Plugin):
 
         if res is None:
             if pattern:
-                e.reply('Found no messages from {} found matching "{}"'.format(nick_, pattern))
+                e.reply('No data for {} found matching "{}"'.format(nick_, pattern))
             else:
-                e.reply('Unknown nick {}'.format(nick_))
+                e.reply('No data for {}'.format(nick_))
 
     @Plugin.command('quote', help=("quote [<nick> [<pattern>]]: looks up quotes from <nick>"
                                     " (optionally only those matching <pattern>)"))
@@ -174,9 +174,9 @@ class Quote(Plugin):
         res = list(self.find_quotes(nick_, channel, pattern))
         if not res:
             if nick_ == '*':
-                e.reply('No quotes recorded')
+                e.reply('No data')
             else:
-                e.reply('No quotes recorded for {}'.format(nick_))
+                e.reply('No data for {}'.format(nick_))
         else:
             out = random.choice(res)
             e.reply(self.format_quote(out, show_channel=False))
@@ -195,7 +195,7 @@ class Quote(Plugin):
             # first argument must be a channel
             data = e['data'].split(maxsplit=1)
             if len(data) < 1:
-                return e.reply('Expected at least <channel> argument in PRIVMSGs, see !help quotes.list')
+                return e.reply('No channel supplied. Syntax for privmsg version is !quote.list <channel> [<pattern>]')
 
             quote_channel = data[0]
 
@@ -223,7 +223,7 @@ class Quote(Plugin):
             return
 
         if len(data) < 1:
-            return e.reply('Expected at least 1 quoteID to remove.')
+            return e.reply('No quoteID supplied')
 
         ids = [qId.strip() for qId in data]
         invalid_ids = []

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -144,8 +144,6 @@ class Quote(Plugin, QuoteDB):
     def quote_set(self, nick, channel, pattern=None):
         """ Insert the last matching quote from a user on a particular channel into the quotes database.
         """
-        user = self.identify_user(nick, channel)
-
         for q in self.channel_logs[channel]:
             if nick == q.nick and channel == q.channel and message_matches(q.message, pattern=pattern):
                 self.insert_quote(q)
@@ -329,24 +327,8 @@ class Quote(Plugin, QuoteDB):
 
         channel = e['channel']
         user = nick(e['user'])
-        ident = self.identify_user(user, channel)
-        ident['message'] = msg
-        ident['nick'] = user  # even for auth'd user, save their nick
         quote = QuoteRecord(None, channel, user, msg)
         self.channel_logs[channel].appendleft(quote)
-
-    def identify_user(self, nick, channel):
-        """Identify a user: by account if authed, if not, by nick. Produces a dict
-        suitable for throwing at mongo."""
-
-        user = self.bot.plugins['usertrack'].get_user(nick)
-
-        if user['account'] is not None:
-            return {'account': user['account'],
-                    'channel': channel}
-        else:
-            return {'nick': nick,
-                    'channel': channel}
 
 def message_matches(msg, pattern=None):
     """ Check whether the given message matches the given pattern

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -8,7 +8,7 @@ import pymongo
 import requests
 
 from csbot.plugin import Plugin
-from csbot.util import nick, subdict
+from csbot.util import nick
 
 
 @attr.s
@@ -50,6 +50,7 @@ class QuoteRecord:
                    nick=udict['nick'],
                    message=udict['message'],
                    )
+
 
 class QuoteDB:
     def __init__(self, *args, **kwargs):
@@ -151,7 +152,8 @@ class Quote(Plugin, QuoteDB):
                 return q
         return None
 
-    @Plugin.command('remember', help=("remember <nick> [<pattern>]: adds last quote that matches <pattern> to the database"))
+    @Plugin.command('remember',
+                    help="remember <nick> [<pattern>]: adds last quote that matches <pattern> to the database")
     def remember(self, e):
         """ Remembers the last matching quote from a user
         """
@@ -175,7 +177,7 @@ class Quote(Plugin, QuoteDB):
             if pattern is not None:
                 e.reply(f'No data for {nick} found matching "{pattern}"')
             else:
-                e.reply( f'No data for {nick}')
+                e.reply(f'No data for {nick}')
         else:
             self.bot.reply(user, 'remembered "{}"'.format(quote.format(show_id=False)))
 
@@ -236,7 +238,9 @@ class Quote(Plugin, QuoteDB):
             if just_channel:
                 return self.reply_with_summary(nick_, just_channel.group('channel'), None)
             elif channel_and_pat:
-                return self.reply_with_summary(nick_, channel_and_pat.group('channel'), channel_and_pat.group('pattern'))
+                return self.reply_with_summary(nick_,
+                                               channel_and_pat.group('channel'),
+                                               channel_and_pat.group('pattern'))
 
             return e.reply('Invalid command. Syntax in privmsg is !quote.list <channel> [<pattern>]')
         else:
@@ -330,6 +334,7 @@ class Quote(Plugin, QuoteDB):
         user = nick(e['user'])
         quote = QuoteRecord(None, channel, user, msg)
         self.channel_logs[channel].appendleft(quote)
+
 
 def message_matches(msg, pattern=None):
     """ Check whether the given message matches the given pattern

--- a/src/csbot/plugins/quote.py
+++ b/src/csbot/plugins/quote.py
@@ -67,8 +67,9 @@ class QuoteDB:
         We keep track of the latest quote ID (they're sequential) in the database
         To update it we remove the old one and insert a new record.
         """
-        self.quotedb.remove({'header': 'currentQuoteId'})
-        self.quotedb.insert({'header': 'currentQuoteId', 'maxQuoteId': id})
+        self.quotedb.replace_one({'header': 'currentQuoteId'},
+                                 {'header': 'currentQuoteId', 'maxQuoteId': id},
+                                 upsert=True)
 
     def get_current_quote_id(self):
         """ Gets the current maximum quote ID
@@ -92,7 +93,7 @@ class QuoteDB:
         id = self.get_current_quote_id()
         sId = id + 1
         quote.quote_id = sId
-        self.quotedb.insert(quote.to_udict())
+        self.quotedb.insert_one(quote.to_udict())
         self.set_current_quote_id(sId)
         return sId
 
@@ -111,7 +112,7 @@ class QuoteDB:
             if not q:
                 return False
 
-            self.quotedb.remove({'quoteId': q.quote_id})
+            self.quotedb.delete_one({'quoteId': q.quote_id})
 
         return True
 

--- a/src/csbot/util.py
+++ b/src/csbot/util.py
@@ -189,6 +189,18 @@ def ordinal(value):
     return ordval
 
 
+def subdict(d1, d2):
+    """returns True if d1 is a "subset" of d2
+    i.e. if forall keys k in d1, k in d2 and d1[k] == d2[k]
+    """
+    for k1 in d1:
+        if k1 not in d2:
+            return False
+        if d1[k1] != d2[k1]:
+            return False
+    return True
+
+
 def pluralize(n, singular, plural):
     return '{0} {1}'.format(n, singular if n == 1 else plural)
 

--- a/tests/test_plugin_quote.py
+++ b/tests/test_plugin_quote.py
@@ -76,7 +76,7 @@ class TestQuotePlugin(BotTestCase):
     @run_client
     def test_client_quotes_not_exist(self):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'No quotes recorded for Nick'))
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
 
     @failsafe
     @run_client
@@ -94,10 +94,10 @@ class TestQuotePlugin(BotTestCase):
         yield from self._recv_privmsg('Nick!~user@host', '#First', 'other data')
 
         yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Unknown nick Nick'))
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
         yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No quotes recorded for Nick'))
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
     @failsafe
     @run_client
@@ -180,7 +180,7 @@ class TestQuotePlugin(BotTestCase):
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove 0')
 
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'No quotes recorded for Nick'))
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
 
     @failsafe
     @run_client

--- a/tests/test_plugin_quote.py
+++ b/tests/test_plugin_quote.py
@@ -1,0 +1,169 @@
+import functools
+import unittest
+import unittest.mock
+
+import mongomock
+
+from csbot.util import subdict
+from csbot.test import BotTestCase, run_client
+
+
+def failsafe(f):
+    """forces the test to fail if not using a mock
+    this prevents the tests from accidentally polluting a real database in the event of failure"""
+    @functools.wraps(f)
+    def decorator(self, *args, **kwargs):
+        assert isinstance(self.quote.quotedb,
+                          mongomock.Collection), 'Not mocking MongoDB -- may be writing to actual database (!) (aborted test)'
+        return f(self, *args, **kwargs)
+    return decorator
+
+class TestQuotePlugin(BotTestCase):
+    CONFIG = """\
+    [@bot]
+    plugins = mongodb usertrack quote
+
+    [mongodb]
+    mode = mock
+    """
+
+    PLUGINS = ['quote']
+
+    def setUp(self):
+        super().setUp()
+
+        if not isinstance(self.quote.paste_quotes, unittest.mock.Mock):
+            self.quote.paste_quotes = unittest.mock.MagicMock(wraps=self.quote.paste_quotes, return_value='N/A')
+
+        self.quote.paste_quotes.reset_mock()
+
+    def _recv_privmsg(self, name, channel, msg):
+        yield from self.client.line_received(':{} PRIVMSG {} :{}'.format(name, channel, msg))
+
+    @failsafe
+    def test_quote_empty(self):
+        assert list(self.quote.find_quotes('noQuotesForMe', '#anyChannel')) == []
+
+    @failsafe
+    @run_client
+    def test_client_quote_add(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', '<Nick> test data'))
+
+    @failsafe
+    @run_client
+    def test_client_quote_add_pattern_find(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes Nick data#2')
+        self.assert_sent('NOTICE {} :{}'.format('#First', '<Nick> test data#2'))
+
+
+    @failsafe
+    @run_client
+    def test_client_quotes_not_exist(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'No quotes recorded for Nick'))
+
+    @failsafe
+    @run_client
+    def test_client_quote_add_multi(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'other data')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick test')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', '<Nick> test data'))
+
+    @failsafe
+    @run_client
+    def test_client_quote_channel_specific_logs(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'other data')
+
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Unknown nick Nick'))
+
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No quotes recorded for Nick'))
+
+    @failsafe
+    @run_client
+    def test_client_quote_channel_specific_quotes(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', 'other data')
+
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', '<Nick> other data'))
+
+        yield from self._recv_privmsg('Another!~user@host', '#First', '!quote Nick')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', '<Nick> test data'))
+
+    @failsafe
+    @run_client
+    def test_client_quote_channel_fill_logs(self):
+        for i in range(150):
+            yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#{}'.format(i))
+            yield from self._recv_privmsg('Nick!~user@host', '#Second', 'other data#{}'.format(i))
+
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick data#135')
+        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', '<Nick> other data#135'))
+
+    @failsafe
+    @run_client
+    def test_client_quotes_format(self):
+        """make sure the format !quotes.list yields is readable and goes to the right place
+        """
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'data test')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quotes.list')
+        self.assert_sent('NOTICE Other :0 - #First - <Nick> data test')
+
+    @failsafe
+    @run_client
+    def test_client_quotes_list(self):
+        """ensure the list !quotes.list sends is short and redirects to pastebin
+        """
+        # stick some quotes in a thing
+        data = ['test data#{}'.format(i) for i in range(10)]
+        for msg in data:
+            yield from self._recv_privmsg('Nick!~user@host', '#First', msg)
+            yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quotes.list')
+
+        quotes = [{'nick': 'Nick', 'channel': '#First', 'message': d, 'quoteId': i} for i, d in enumerate(data)]
+        msgs = ['NOTICE {channel} :{msg}'.format(channel='Other', msg=self.quote.format_quote(q)) for q in quotes]
+        self.assert_sent(msgs[:5])
+
+        # manually unroll the call args to map subdict over it
+        # so we can ignore the cruft mongo inserts
+        quote_calls = self.quote.paste_quotes.call_args
+        qarg, = quote_calls[0]  # args
+        for quote, document in zip(quotes, qarg):
+            assert subdict(quote, document)
+
+    @failsafe
+    @run_client
+    def test_client_quote_remove(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
+        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes.remove -1')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes.remove 0')
+
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quotes Nick')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'No quotes recorded for Nick'))
+

--- a/tests/test_plugin_quote.py
+++ b/tests/test_plugin_quote.py
@@ -135,7 +135,7 @@ class TestQuotePlugin(BotTestCase):
         yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
 
         yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote.list')
-        self.assert_sent('NOTICE Other :(0) - #Second - <Nick> data test')
+        self.assert_sent('NOTICE Other :[0] - #Second - <Nick> data test')
 
     @failsafe
     @run_client

--- a/tests/test_plugin_quote.py
+++ b/tests/test_plugin_quote.py
@@ -32,11 +32,11 @@ class TestQuotePlugin:
         pytest.mark.bot(config="""
             ["@bot"]
             plugins = ["mongodb", "usertrack", "auth", "quote"]
-            
+
             [auth]
             nickaccount  = "#First:quote"
             otheraccount = "#Second:quote"
-            
+
             [mongodb]
             mode = "mock"
         """),
@@ -96,7 +96,7 @@ class TestQuotePlugin:
 
     async def test_client_quotes_not_exist(self):
         await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
+        self.bot_helper.assert_sent('NOTICE #First :No data for Nick')
 
     async def test_client_quote_add_multi(self):
         await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
@@ -110,10 +110,10 @@ class TestQuotePlugin:
         await self._recv_privmsg('Nick!~user@host', '#First', 'other data')
 
         await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+        self.bot_helper.assert_sent('NOTICE #Second :No data for Nick')
 
         await self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+        self.bot_helper.assert_sent('NOTICE #Second :No data for Nick')
 
     async def test_client_quote_channel_specific_quotes(self):
         await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
@@ -129,8 +129,8 @@ class TestQuotePlugin:
 
     async def test_client_quote_channel_fill_logs(self):
         for i in range(150):
-            await self._recv_privmsg('Nick!~user@host', '#First', 'test data#{}'.format(i))
-            await self._recv_privmsg('Nick!~user@host', '#Second', 'other data#{}'.format(i))
+            await self._recv_privmsg('Nick!~user@host', '#First', f'test data#{i}')
+            await self._recv_privmsg('Nick!~user@host', '#Second', f'other data#{i}')
 
         await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick data#135')
         await self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
@@ -154,7 +154,7 @@ class TestQuotePlugin:
         await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
 
         # stick some quotes in a thing
-        data = ['test data#{}'.format(i) for i in range(10)]
+        data = [f'test data#{i}' for i in range(10)]
         for msg in data:
             await self._recv_privmsg('Nick!~user@host', '#Second', msg)
             await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
@@ -187,7 +187,7 @@ class TestQuotePlugin:
         await self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove 0')
 
         await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
+        self.bot_helper.assert_sent('NOTICE #First :No data for Nick')
 
     async def test_client_quote_remove_no_permission(self):
         await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
@@ -196,13 +196,13 @@ class TestQuotePlugin:
         await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
         await self._recv_privmsg('Other!~user@host', '#First', '!quote.remove -1')
 
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
+        self.bot_helper.assert_sent('NOTICE #First :error: otheraccount not authorised for #First:quote')
 
     async def test_client_quote_remove_no_quotes(self):
         await self._recv_line(":Nick!~user@host ACCOUNT nickaccount")
         await self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove -1')
 
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'Error: could not remove quote(s) with ID: -1'))
+        self.bot_helper.assert_sent('NOTICE #First :Error: could not remove quote(s) with ID: -1')
 
     async def test_client_quote_list_no_permission(self):
         await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
@@ -211,7 +211,7 @@ class TestQuotePlugin:
         await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
         await self._recv_privmsg('Other!~user@host', '#First', '!quote.list')
 
-        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
+        self.bot_helper.assert_sent('NOTICE #First :error: otheraccount not authorised for #First:quote')
 
     async def test_client_quote_channelwide(self):
         await self._recv_privmsg('Nick!~user@host', '#First', 'test data!')

--- a/tests/test_plugin_quote.py
+++ b/tests/test_plugin_quote.py
@@ -1,24 +1,12 @@
-import functools
-import unittest
-import unittest.mock
+import asyncio
+from unittest import mock
 
 import mongomock
-
-from csbot.util import subdict
-from csbot.test import BotTestCase, run_client
+import pytest
 
 from csbot.plugins.quote import QuoteRecord
+from csbot.util import subdict
 
-
-def failsafe(f):
-    """forces the test to fail if not using a mock
-    this prevents the tests from accidentally polluting a real database in the event of failure"""
-    @functools.wraps(f)
-    def decorator(self, *args, **kwargs):
-        assert isinstance(self.quote.quotedb,
-                          mongomock.Collection), 'Not mocking MongoDB -- may be writing to actual database (!) (aborted test)'
-        return f(self, *args, **kwargs)
-    return decorator
 
 class TestQuoteRecord:
     def test_quote_formatter(self):
@@ -39,156 +27,145 @@ class TestQuoteRecord:
         assert qr.to_udict() == udict
 
 
-class TestQuotePlugin(BotTestCase):
-    CONFIG = """\
-    [@bot]
-    plugins = mongodb usertrack auth quote
+class TestQuotePlugin:
+    pytestmark = [
+        pytest.mark.bot(config="""
+            ["@bot"]
+            plugins = ["mongodb", "usertrack", "auth", "quote"]
+            
+            [auth]
+            nickaccount  = "#First:quote"
+            otheraccount = "#Second:quote"
+            
+            [mongodb]
+            mode = "mock"
+        """),
+        pytest.mark.usefixtures("run_client"),
+    ]
 
-    [auth]
-    nickaccount  = #First:quote
-    otheraccount = #Second:quote
+    @pytest.fixture(autouse=True)
+    def quote_plugin(self, bot_helper):
+        self.bot_helper = bot_helper
+        self.quote = self.bot_helper['quote']
 
-    [mongodb]
-    mode = mock
-    """
+        # Force the test to fail if not using a mock database. This prevents the tests from accidentally
+        # polluting a real database in the evnet of failure.
+        assert isinstance(self.quote.quotedb, mongomock.Collection), \
+            'Not mocking MongoDB -- may be writing to actual database (!) (aborted test)'
 
-    PLUGINS = ['quote']
+        self.mock_paste_quotes = mock.MagicMock(wraps=self.quote.paste_quotes, return_value='N/A')
+        with mock.patch.object(self.quote, 'paste_quotes', self.mock_paste_quotes):
+            yield
 
-    def setUp(self):
-        super().setUp()
+    async def _recv_line(self, line):
+        return await asyncio.wait(self.bot_helper.receive(line))
 
-        if not isinstance(self.quote.paste_quotes, unittest.mock.Mock):
-            self.quote.paste_quotes = unittest.mock.MagicMock(wraps=self.quote.paste_quotes, return_value='')
-
-        self.quote.paste_quotes.reset_mock()
-
-    def _recv_privmsg(self, name, channel, msg):
-        yield from self.client.line_received(':{} PRIVMSG {} :{}'.format(name, channel, msg))
+    async def _recv_privmsg(self, name, channel, msg):
+        return await self._recv_line(f':{name} PRIVMSG {channel} :{msg}')
 
     def assert_sent_quote(self, channel, quote_id, quoted_user, quoted_channel, quoted_text, show_channel=False):
         quote = QuoteRecord(quote_id=quote_id,
                             channel=quoted_channel,
                             nick=quoted_user,
                             message=quoted_text)
-        self.assert_sent('NOTICE {} :{}'.format(channel, quote.format()))
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format(channel, quote.format()))
 
-    @failsafe
     def test_quote_empty(self):
         assert list(self.quote.find_quotes('noQuotesForMe', '#anyChannel')) == []
 
-    @failsafe
-    @run_client
-    def test_client_quote_add(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
+    async def test_client_quote_add(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
         self.assert_sent_quote('#First', 0, 'Nick', '#First', 'test data')
 
-    @failsafe
-    @run_client
-    def test_client_quote_remember_send_privmsg(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
-        self.assert_sent('NOTICE Other :remembered "<Nick> test data"')
+    async def test_client_quote_remember_send_privmsg(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        self.bot_helper.assert_sent('NOTICE Other :remembered "<Nick> test data"')
 
-    @failsafe
-    @run_client
-    def test_client_quote_add_pattern_find(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+    async def test_client_quote_add_pattern_find(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick data#2')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick data#2')
         self.assert_sent_quote('#First', 1, 'Nick', '#First', 'test data#2')
 
-    @failsafe
-    @run_client
-    def test_client_quotes_not_exist(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
+    async def test_client_quotes_not_exist(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
 
-    @failsafe
-    @run_client
-    def test_client_quote_add_multi(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'other data')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick test')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
+    async def test_client_quote_add_multi(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'other data')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick test')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
         self.assert_sent_quote('#First', 0, 'Nick', '#First', 'test data')
 
-    @failsafe
-    @run_client
-    def test_client_quote_channel_specific_logs(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'other data')
+    async def test_client_quote_channel_specific_logs(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'other data')
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+        await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
+        await self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
-    @failsafe
-    @run_client
-    def test_client_quote_channel_specific_quotes(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data')
-        yield from self._recv_privmsg('Nick!~user@host', '#Second', 'other data')
+    async def test_client_quote_channel_specific_quotes(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data')
+        await self._recv_privmsg('Nick!~user@host', '#Second', 'other data')
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
         self.assert_sent_quote('#Second', 0, 'Nick', '#Second', 'other data')
 
-        yield from self._recv_privmsg('Another!~user@host', '#First', '!remember Nick')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
+        await self._recv_privmsg('Another!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Other!~user@host', '#First', '!quote Nick')
         self.assert_sent_quote('#First', 1, 'Nick', '#First', 'test data')
 
-    @failsafe
-    @run_client
-    def test_client_quote_channel_fill_logs(self):
+    async def test_client_quote_channel_fill_logs(self):
         for i in range(150):
-            yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#{}'.format(i))
-            yield from self._recv_privmsg('Nick!~user@host', '#Second', 'other data#{}'.format(i))
+            await self._recv_privmsg('Nick!~user@host', '#First', 'test data#{}'.format(i))
+            await self._recv_privmsg('Nick!~user@host', '#Second', 'other data#{}'.format(i))
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick data#135')
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick data#135')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!quote Nick')
         self.assert_sent_quote('#Second', 0, 'Nick', '#Second', 'other data#135')
 
-    @failsafe
-    @run_client
-    def test_client_quotes_format(self):
+    async def test_client_quotes_format(self):
         """make sure the format !quote.list yields is readable and goes to the right place
         """
-        yield from self.client.line_received(":Other!~other@otherhost ACCOUNT otheraccount")
+        await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
 
-        yield from self._recv_privmsg('Nick!~user@host', '#Second', 'data test')
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
+        await self._recv_privmsg('Nick!~user@host', '#Second', 'data test')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote.list')
-        self.assert_sent('NOTICE Other :[0] - #Second - <Nick> data test')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!quote.list')
+        self.bot_helper.assert_sent('NOTICE Other :[0] - #Second - <Nick> data test')
 
-    @failsafe
-    @run_client
-    def test_client_quotes_list(self):
+    async def test_client_quotes_list(self):
         """ensure the list !quote.list sends is short and redirects to pastebin
         """
-        yield from self.client.line_received(":Nick!~user@host ACCOUNT nickaccount")
-        yield from self.client.line_received(":Other!~other@otherhost ACCOUNT otheraccount")
+        await self._recv_line(":Nick!~user@host ACCOUNT nickaccount")
+        await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
 
         # stick some quotes in a thing
         data = ['test data#{}'.format(i) for i in range(10)]
         for msg in data:
-            yield from self._recv_privmsg('Nick!~user@host', '#Second', msg)
-            yield from self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
+            await self._recv_privmsg('Nick!~user@host', '#Second', msg)
+            await self._recv_privmsg('Other!~user@host', '#Second', '!remember Nick')
 
-        yield from self._recv_privmsg('Other!~user@host', '#Second', '!quote.list')
+        await self._recv_privmsg('Other!~user@host', '#Second', '!quote.list')
 
         quotes = [QuoteRecord(quote_id=i, channel='#Second', nick='Nick', message=d) for i, d in enumerate(data)]
         quotes = reversed(quotes)
         msgs = ['NOTICE {channel} :{msg}'.format(channel='Other',
                                                  msg=q.format(show_channel=True)) for q in quotes]
-        self.assert_sent(msgs[:5])
+        self.bot_helper.assert_sent(msgs[:5])
 
         # manually unroll the call args to map subdict over it
         # so we can ignore the cruft mongo inserts
@@ -197,68 +174,57 @@ class TestQuotePlugin(BotTestCase):
         for quote, document in zip(quotes, qarg):
             assert subdict(quote, document)
 
-    @failsafe
-    @run_client
-    def test_client_quote_remove(self):
-        yield from self.client.line_received(":Nick!~user@host ACCOUNT nickaccount")
+    async def test_client_quote_remove(self):
+        await self._recv_line(":Nick!~user@host ACCOUNT nickaccount")
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#2')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove -1')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove 0')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove -1')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove 0')
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote Nick')
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
 
-    @failsafe
-    @run_client
-    def test_client_quote_remove_no_permission(self):
-        yield from self.client.line_received(":Other!~other@otherhost ACCOUNT otheraccount")
+    async def test_client_quote_remove_no_permission(self):
+        await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote.remove -1')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Other!~user@host', '#First', '!quote.remove -1')
 
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
 
-    @failsafe
-    @run_client
-    def test_client_quote_remove_no_quotes(self):
-        yield from self.client.line_received(":Nick!~user@host ACCOUNT nickaccount")
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove -1')
+    async def test_client_quote_remove_no_quotes(self):
+        await self._recv_line(":Nick!~user@host ACCOUNT nickaccount")
+        await self._recv_privmsg('Nick!~user@host', '#First', '!quote.remove -1')
 
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'Error: could not remove quote(s) with ID: -1'))
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'Error: could not remove quote(s) with ID: -1'))
 
-    @failsafe
-    @run_client
-    def test_client_quote_list_no_permission(self):
-        yield from self.client.line_received(":Other!~other@otherhost ACCOUNT otheraccount")
+    async def test_client_quote_list_no_permission(self):
+        await self._recv_line(":Other!~other@otherhost ACCOUNT otheraccount")
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
-        yield from self._recv_privmsg('Other!~user@host', '#First', '!quote.list')
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data#1')
+        await self._recv_privmsg('Other!~user@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Other!~user@host', '#First', '!quote.list')
 
-        self.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
+        self.bot_helper.assert_sent('NOTICE {} :{}'.format('#First', 'error: otheraccount not authorised for #First:quote'))
 
-    @run_client
-    def test_client_quote_channelwide(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data!')
-        yield from self._recv_privmsg('Other!~other@host', '#First', '!remember Nick')
-        yield from self._recv_privmsg('Other!~other@host', '#First', '!quote')
+    async def test_client_quote_channelwide(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data!')
+        await self._recv_privmsg('Other!~other@host', '#First', '!remember Nick')
+        await self._recv_privmsg('Other!~other@host', '#First', '!quote')
         self.assert_sent_quote('#First', 0, 'Nick', '#First', 'test data!')
 
-    @failsafe
-    @run_client
-    def test_client_quote_channelwide_with_pattern(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', 'test data!')
-        yield from self._recv_privmsg('Other!~other@host', '#First', '!remember Nick')
+    async def test_client_quote_channelwide_with_pattern(self):
+        await self._recv_privmsg('Nick!~user@host', '#First', 'test data!')
+        await self._recv_privmsg('Other!~other@host', '#First', '!remember Nick')
 
-        yield from self._recv_privmsg('Other!~other@host', '#First', 'other data')
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!remember Other')
+        await self._recv_privmsg('Other!~other@host', '#First', 'other data')
+        await self._recv_privmsg('Nick!~user@host', '#First', '!remember Other')
 
-        yield from self._recv_privmsg('Other!~other@host', '#First', '!quote * other')
+        await self._recv_privmsg('Other!~other@host', '#First', '!quote * other')
         self.assert_sent_quote('#First', 1, 'Other', '#First', 'other data')


### PR DESCRIPTION
Adds a quote plugin with these commands:

(all commands are channel-specific)

- `remember <nick> [<pattern>]`
  - remembers a message <nick> sent that matches <pattern>
  - if no pattern then just last message <nick> sent
  - `NOTICE`s the user that !remember'd with a confirmation it was remembered
- `quote [<nick> [<pattern>]]`
  - recalls a quote by <nick> that was !remember'd
  - if no <nick> it defaults to `*` which is channel-wide quoting
  - Nondeterministically selects a matching quote to send to the channel
- `quote.remove <id> [, <id>]*`
  - removes one-or-more quote ID's from the database
  - requires auth
- `quote.list [<pattern>]`
  - privately sends a list of quotes that match <pattern> (or a pastebin link if too many)
  - (only pastes the first ~100 for pastebin)
  - requires auth
  - can be used in private chats but then syntax becomes `quote.list <channel> [<pattern>]`

Closes #100