### PR TITLE
Reorganise whois.set functionality

### DIFF
--- a/csbot/plugins/whois.py
+++ b/csbot/plugins/whois.py
@@ -48,24 +48,35 @@ class Whois(Plugin):
         else:
             e.reply('{}: {}'.format(nick_, str(res)))
 
-
-    @Plugin.command('whois.setdefault', help=('whois.setdefault [default_whois]: sets the default'
-                                              ' whois text for the user, used when no channel-specific'
-                                              ' one is set'))
-    def setdefault(self, e):
-        self.whois_set(nick(e['user']), e['data'], channel=None)
-
-    @Plugin.command('whois.set')
-    def set(self, e):
+    @Plugin.command('whois.setlocal', help=('whois.setlocal [whois_text]: sets the whois text'
+                                            ' for the user, but only for the current channel.'))
+    def setlocal(self, e):
         """Allow a user to associate data with themselves for this channel."""
         self.whois_set(nick(e['user']), e['data'], channel=e['channel'])
 
+    @Plugin.command('whois.setdefault', help=('whois.setdefault [default_whois]: sets the default'
+                                              ' whois text for the user, used when no channel-specific'
+                                              ' one is set.'))
+    def setdefault(self, e):
+        self.whois_set(nick(e['user']), e['data'], channel=None)
 
-    @Plugin.command('whois.unset')
+    @Plugin.command('whois.set', help=('Alias for whois.setdefault.'))
+    def set(self, e):
+        """Allow a user to associate data with themselves for this channel."""
+        return self.setdefault(e)   
+
+    @Plugin.command('whois.unset', help=('Alias for whois.unsetdefault'))
     def unset(self, e):
+        return self.unsetdefault(e)
+
+    @Plugin.command('whois.unsetlocal', help=('whois.unsetlocal: unsets the local whois text for the user'
+                                              ' but only for this channel'
+                                              ' (the global whois for the user is unaffected).'))
+    def unsetlocal(self, e):
         self.whois_unset(nick(e['user']), channel=e['channel'])
 
-    @Plugin.command('whois.unsetdefault')
+    @Plugin.command('whois.unsetdefault', help='whois.unsetdefault: unsets the global whois text for the user.'
+                                               ' Locally set whois texts will be unaffected.')
     def unsetdefault(self, e):
         self.whois_unset(nick(e['user']))
 

--- a/csbot/plugins/whois.py
+++ b/csbot/plugins/whois.py
@@ -49,14 +49,14 @@ class Whois(Plugin):
             e.reply('{}: {}'.format(nick_, str(res)))
 
     @Plugin.command('whois.setlocal', help=('whois.setlocal [whois_text]: sets the whois text'
-                                            ' for the user, but only for the current channel.'))
+                                            ' for the user, but only for the current channel'))
     def setlocal(self, e):
         """Allow a user to associate data with themselves for this channel."""
         self.whois_set(nick(e['user']), e['data'], channel=e['channel'])
 
     @Plugin.command('whois.setdefault', help=('whois.setdefault [default_whois]: sets the default'
                                               ' whois text for the user, used when no channel-specific'
-                                              ' one is set.'))
+                                              ' one is set'))
     def setdefault(self, e):
         self.whois_set(nick(e['user']), e['data'], channel=None)
 
@@ -71,12 +71,12 @@ class Whois(Plugin):
 
     @Plugin.command('whois.unsetlocal', help=('whois.unsetlocal: unsets the local whois text for the user'
                                               ' but only for this channel'
-                                              ' (the global whois for the user is unaffected).'))
+                                              ' (the global whois for the user is unaffected'))
     def unsetlocal(self, e):
         self.whois_unset(nick(e['user']), channel=e['channel'])
 
     @Plugin.command('whois.unsetdefault', help='whois.unsetdefault: unsets the global whois text for the user.'
-                                               ' Locally set whois texts will be unaffected.')
+                                               ' Locally set whois texts will be unaffected')
     def unsetdefault(self, e):
         self.whois_unset(nick(e['user']))
 

--- a/csbot/test/test_plugin_whois.py
+++ b/csbot/test/test_plugin_whois.py
@@ -101,22 +101,22 @@ class TestWhoisPlugin(BotTestCase):
     @failsafe
     @run_client
     def test_client_reply_whois_after_set(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test1')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
 
     @failsafe
     @run_client
     def test_client_reply_whois_different_channel(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test1')
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))
 
     @failsafe
     @run_client
     def test_client_reply_whois_multiple_users_channels(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
-        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois.set test2')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois.setlocal test2')
 
         yield from self._recv_privmsg('Other!~other@otherhost', '#First', '!whois Nick')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
@@ -127,9 +127,24 @@ class TestWhoisPlugin(BotTestCase):
     @failsafe
     @run_client
     def test_client_reply_whois_self(self):
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test1')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test1'))
+
+    @failsafe
+    @run_client
+    def test_set_alias(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test1'))
+
+    @failsafe
+    @run_client
+    def test_unset_alias(self):
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test1')
+        yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois.unset')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
+        self.assert_sent('NOTICE {} :{}'.format('#First', 'No data for Nick'))
 
     @failsafe
     @run_client
@@ -141,7 +156,7 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Other!~other@otherhost', '#Third', '!whois Nick')
         self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test first')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test first')
 
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test first'))
@@ -155,11 +170,11 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#Second', 'Nick: test data'))
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.set test first')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.setlocal test first')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test first'))
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.unset')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.unsetlocal')
         yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#First', 'Nick: test data'))
 
@@ -174,7 +189,7 @@ class TestWhoisPlugin(BotTestCase):
         yield from self._recv_privmsg('Other!~other@otherhost', '#Third', '!whois Nick')
         self.assert_sent('NOTICE {} :{}'.format('#Third', 'Nick: test data'))
 
-        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.unsetdefault')
+        yield from self._recv_privmsg('Nick!~user@host', '#First', '!whois.unset')
 
         yield from self._recv_privmsg('Nick!~user@host', '#Second', '!whois')
         self.assert_sent('NOTICE {} :{}'.format('#Second', 'No data for Nick'))


### PR DESCRIPTION
Alias !whois.set to !whois.setdefault and add !whois.setlocal.
Also alias !whois.unset to !whois.unsetdefault and add !whois.unsetlocal

This PR also adds useful !help text for the commands in the whois plugin.