### PR TITLE
Prepare for mLab update to MongoDB 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for deployment
 click>=6.2,<7.0
 straight.plugin==1.4.0-post-1
-pymongo>=3.4.0
+pymongo>=3.6.0
 requests>=2.9.1,<3.0.0
 lxml>=2.3.5
 google-api-python-client>=1.4.1,<2.0.0


### PR DESCRIPTION
* https://docs.mlab.com/db-version-requirements/#v36
* https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#python-driver-compatibility