### PR TITLE
Remove Mathison from #compsoc-uk

### DIFF
--- a/csbot.deploy.cfg
+++ b/csbot.deploy.cfg
@@ -1,14 +1,11 @@
 [@bot]
 nickname = Mathison
 auth_method = sasl_plain
-channels = #cs-york #cs-york-dev #compsoc-uk #hacksoc
+channels = #cs-york #cs-york-dev #hacksoc
 plugins = logger linkinfo hoogle imgur csyork usertrack auth topic helix calc mongodb termdates whois xkcd youtube last
 
 [linkinfo]
 scan_limit = 2
-
-[linkinfo/#compsoc-uk]
-scan_limit = 0
 
 [auth]
 @everything = * *:*


### PR DESCRIPTION
#134 didn't work as intended (see issue #135), and repeated spam youtube urls have meant that mathison has been killed globally by the anti-spam.

As a "temporary" measure, remove Mathison from #compsoc-uk