### PR TITLE
Make sure csbot can't get two'd in hacksoc's slack

### DIFF
--- a/csbot/irc.py
+++ b/csbot/irc.py
@@ -385,6 +385,12 @@ class IRCClient:
         Encodes, terminates and sends *data* to the server.
         """
         LOG.debug('<<< %s', data)
+        # Protect csbot from getting two'd
+        try:
+            if data.split(':')[1].strip() == '2':
+                data = ''.join(c if c!='2' else u'ᒿ' for c in data)
+        except IndexError:
+            pass
         data = self.codec.encode(data) + b'\r\n'
         self.writer.write(data)
 


### PR DESCRIPTION
Any message that is just a 2 gets changed to a "Unified Canadian Aboriginal Syllabics ᒿ"
:^^^^^^^^)