### PR TITLE
Fix race conditions

### DIFF
--- a/csbot/core.py
+++ b/csbot/core.py
@@ -161,8 +161,7 @@ class Bot(SpecialPlugin, IRCClient):
             self.post_event(command)
 
     @Plugin.hook('core.command')
-    @asyncio.coroutine
-    def fire_command(self, event):
+    async def fire_command(self, event):
         """Dispatch a command event to its callback.
         """
         # Ignore unknown commands
@@ -170,9 +169,11 @@ class Bot(SpecialPlugin, IRCClient):
             return
 
         f, _, _ = self.commands[event['command']]
-        if not asyncio.iscoroutinefunction(f):
-            f = asyncio.coroutine(f)
-        yield from f(event)
+        # Done like this instead of `if asyncio.iscoroutinefunction(...):` because `f` is a
+        # csbot.plugin.LazyMethod object
+        result = f(event)
+        if asyncio.iscoroutine(result):
+            await result
 
     @Plugin.command('help', help=('help [command]: show help for command, or '
                                   'show available commands'))

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -23,6 +23,7 @@ class Bot(SpecialPlugin, IRCClient):
 
     #: Default configuration values
     CONFIG_DEFAULTS = {
+        'ircv3': False,
         'nickname': 'csyorkbot',
         'password': None,
         'auth_method': 'pass',
@@ -71,6 +72,7 @@ class Bot(SpecialPlugin, IRCClient):
         IRCClient.__init__(
             self,
             loop=loop,
+            ircv3=self.config_getboolean('ircv3'),
             nick=self.config_get('nickname'),
             username=self.config_get('username'),
             host=self.config_get('irc_host'),
@@ -207,6 +209,8 @@ class Bot(SpecialPlugin, IRCClient):
 
     async def connection_made(self):
         await super().connection_made()
+        if self.config_getboolean('ircv3'):
+            await self.request_capabilities(enable={'account-notify', 'extended-join'})
         self.emit_new('core.raw.connected')
 
     async def connection_lost(self, exc):
@@ -327,14 +331,6 @@ class Bot(SpecialPlugin, IRCClient):
             'names': names,
             'raw_names': raw_names,
         })
-
-    # "IRC Client Capabilities"
-
-    def on_capabilities_available(self, capabilities):
-        super().on_capabilities_available(capabilities)
-        for cap in ['account-notify', 'extended-join']:
-            if cap in capabilities and cap not in self.enabled_capabilities:
-                self.enable_capability(cap)
 
     # Implement active account discovery via "formatted WHO"
 

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -205,12 +205,12 @@ class Bot(SpecialPlugin, IRCClient):
         """
         self.bot.post_event(event)
 
-    def connection_made(self):
-        super().connection_made()
+    async def connection_made(self):
+        await super().connection_made()
         self.emit_new('core.raw.connected')
 
-    def connection_lost(self, exc):
-        super().connection_lost(exc)
+    async def connection_lost(self, exc):
+        await super().connection_lost(exc)
         self.emit_new('core.raw.disconnected', {'reason': repr(exc)})
 
     def send_line(self, line):

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -1,6 +1,5 @@
 import collections
 import itertools
-
 import asyncio
 
 import configparser
@@ -97,7 +96,7 @@ class Bot(SpecialPlugin, IRCClient):
         self.commands = {}
 
         # Event runner
-        self.events = events.AsyncEventRunner(self._fire_hooks, self.loop)
+        self.events = events.HybridEventRunner(self._get_hooks, self.loop)
 
         # Keeps partial name lists between RPL_NAMREPLY and
         # RPL_ENDOFNAMES events
@@ -113,9 +112,8 @@ class Bot(SpecialPlugin, IRCClient):
         """
         self.plugins.teardown()
 
-    def _fire_hooks(self, event):
-        results = self.plugins.fire_hooks(event)
-        return list(itertools.chain(*results))
+    def _get_hooks(self, event):
+        return itertools.chain(*self.plugins.get_hooks(event.event_type))
 
     def post_event(self, event):
         return self.events.post_event(event)

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -1,6 +1,5 @@
 import collections
 import itertools
-import asyncio
 
 import configparser
 import straight.plugin

--- a/csbot/core.py
+++ b/csbot/core.py
@@ -9,6 +9,7 @@ from csbot.plugin import Plugin, SpecialPlugin
 from csbot.plugin import build_plugin_dict, PluginManager
 import csbot.events as events
 from csbot.events import Event, CommandEvent
+from csbot.util import maybe_future_result
 
 from .irc import IRCClient, IRCUser
 
@@ -169,11 +170,7 @@ class Bot(SpecialPlugin, IRCClient):
             return
 
         f, _, _ = self.commands[event['command']]
-        # Done like this instead of `if asyncio.iscoroutinefunction(...):` because `f` is a
-        # csbot.plugin.LazyMethod object
-        result = f(event)
-        if asyncio.iscoroutine(result):
-            await result
+        await maybe_future_result(f(event), log=self.log)
 
     @Plugin.command('help', help=('help [command]: show help for command, or '
                                   'show available commands'))

--- a/csbot/events.py
+++ b/csbot/events.py
@@ -8,7 +8,6 @@ from csbot.util import parse_arguments
 
 
 LOG = logging.getLogger('csbot.events')
-LOG.setLevel(logging.INFO)
 
 
 class ImmediateEventRunner(object):
@@ -190,9 +189,11 @@ class HybridEventRunner:
             LOG.debug('processing events (%s remaining)', len(self.events))
             # Get next event
             event = self.events.popleft()
+            LOG.debug('processing event: %s', event)
             # Handle the event
             for handler in self.get_handlers(event):
                 # Attempt to run the handler, but don't break everything if the handler fails
+                LOG.debug('running handler: %r', handler)
                 try:
                     result = handler(event)
                 except Exception as e:

--- a/csbot/irc.py
+++ b/csbot/irc.py
@@ -362,6 +362,9 @@ class IRCClient:
                 # use in the IRCMessage (which later encodes it as utf-8...)
                 sasl_plain_b64 = base64.b64encode(sasl_plain.encode('utf-8')).decode('ascii')
                 self.send(IRCMessage.create('AUTHENTICATE', [sasl_plain_b64]))
+                sasl_success = await self.wait_for_message(lambda m: (m.command in ('903', '904'), m.command == '903'))
+                if not sasl_success:
+                    LOG.error('SASL authentication failed')
             else:
                 LOG.error('could not enable "sasl" capability, skipping authentication')
         else:

--- a/csbot/irc.py
+++ b/csbot/irc.py
@@ -373,9 +373,6 @@ class IRCClient:
         if self.__config['ircv3']:
             self.send(IRCMessage.create('CAP', ['END']))
 
-        # TODO: uncomment this? tests hang if uncommented...
-        # await self.wait_for_message(lambda m: (m.command_name == 'RPL_WELCOME', m))
-
         self._start_client_pings()
 
     async def connection_lost(self, exc):

--- a/csbot/irc.py
+++ b/csbot/irc.py
@@ -273,9 +273,9 @@ class IRCClient:
             await self.connect()
             self.connected.set()
             self.disconnected.clear()
-            self.connection_made()
+            await self.connection_made()
             await self.read_loop()
-            self.connection_lost(self.reader.exception())
+            await self.connection_lost(self.reader.exception())
             self.connected.clear()
             self.disconnected.set()
             if self._exiting:
@@ -318,7 +318,7 @@ class IRCClient:
                 break
             self.line_received(self.codec.decode(line[:-2]))
 
-    def connection_made(self):
+    async def connection_made(self):
         """Callback for successful connection.
 
         Register with the IRC server.
@@ -362,7 +362,7 @@ class IRCClient:
 
         self._start_client_pings()
 
-    def connection_lost(self, exc):
+    async def connection_lost(self, exc):
         """Handle a broken connection by attempting to reconnect.
 
         Won't reconnect if the broken connection was deliberate (i.e.

--- a/csbot/irc.py
+++ b/csbot/irc.py
@@ -510,26 +510,6 @@ class IRCClient:
             return False, None
         return self.wait_for_message(predicate)
 
-    def enable_capability(self, name):
-        """Enable client capability *name*.
-
-        Should wait for :meth:`on_capability_enabled` before assuming it is
-        enabled.
-        """
-        if name not in self.available_capabilities:
-            LOG.warning('Enabling client capability "{}" not in response to CAP LS'.format(name))
-        self.send_line('CAP REQ :{}'.format(name))
-
-    def disable_capability(self, name):
-        """Disable client capability *name*.
-
-        Should wait for :meth:`on_capability_disabled` befor assuming it is
-        disabled.
-        """
-        if name not in self.available_capabilities:
-            LOG.warning('Disabling client capability "{}" not in response to CAP LS'.format(name))
-        self.send_line('CAP REQ :-{}'.format(name))
-
     def set_nick(self, nick):
         """Ask the server to set our nick."""
         self.send_line('NICK {}'.format(nick))

--- a/csbot/plugin.py
+++ b/csbot/plugin.py
@@ -3,6 +3,7 @@ from collections import abc
 import logging
 import os
 import asyncio
+from typing import List, Callable
 
 
 def build_plugin_dict(plugins):
@@ -268,19 +269,10 @@ class Plugin(object, metaclass=PluginMeta):
         """
         return ProvidedByPlugin(other, kwargs)
 
-    def fire_hooks(self, event):
-        """Execute all of this plugin's handlers for *event*.
-
-        All handlers are treated as coroutine functions, and the return value is
-        a list of all the invoked coroutines.
+    def get_hooks(self, hook: str) -> List[Callable]:
+        """Get a list of this plugin's handlers for *hook*.
         """
-        coros = []
-        for name in self.plugin_hooks.get(event.event_type, ()):
-            f = getattr(self, name)
-            if not asyncio.iscoroutinefunction(f):
-                f = asyncio.coroutine(f)
-            coros.append(f(event))
-        return coros
+        return [getattr(self, name) for name in self.plugin_hooks.get(hook, ())]
 
     def provide(self, plugin_name, **kwarg):
         """Provide a value for a :meth:`Plugin.use` usage."""

--- a/csbot/plugin.py
+++ b/csbot/plugin.py
@@ -2,7 +2,6 @@ import collections
 from collections import abc
 import logging
 import os
-import asyncio
 from typing import List, Callable
 
 

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -5,8 +5,8 @@ import collections
 from collections import namedtuple
 import datetime
 from functools import partial
+import asyncio
 
-import requests
 import aiohttp
 import lxml.etree
 import lxml.html
@@ -186,7 +186,10 @@ class LinkInfo(Plugin):
         for h in self.handlers:
             match = h.filter(url)
             if match:
-                result = h.handler(url, match)
+                if asyncio.iscoroutinefunction(h.handler):
+                    result = await h.handler(url, match)
+                else:
+                    result = h.handler(url, match)
                 if result is not None:
                     # Useful result, return it
                     return result

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -103,7 +103,7 @@ class LinkInfo(Plugin):
         self.excludes.append(filter)
 
     @Plugin.command('link')
-    def link_command(self, e):
+    async def link_command(self, e):
         """Handle the "link" command.
 
         Fetch information about a specified URL, e.g.
@@ -123,7 +123,7 @@ class LinkInfo(Plugin):
             url = 'http://' + url
 
         # Get info for the URL
-        result = self.get_link_info(url)
+        result = await self.get_link_info(url)
         self._log_if_error(result)
         # See if it was marked as NSFW in the command text
         result.nsfw |= 'nsfw' in rest.lower()
@@ -131,7 +131,7 @@ class LinkInfo(Plugin):
         e.reply(result.get_message())
 
     @Plugin.hook('core.message.privmsg')
-    def scan_privmsg(self, e):
+    async def scan_privmsg(self, e):
         """Scan the data of PRIVMSG events for URLs and respond with
         information about them.
         """
@@ -152,7 +152,7 @@ class LinkInfo(Plugin):
                 break
 
             # Get info for the URL
-            result = self.get_link_info(part)
+            result = await self.get_link_info(part)
             self._log_if_error(result)
 
             if result.is_error:
@@ -168,7 +168,7 @@ class LinkInfo(Plugin):
                 # ... and since we got a useful result, stop processing the message
                 break
 
-    def get_link_info(self, original_url):
+    async def get_link_info(self, original_url):
         """Get information about a URL.
 
         Using the *original_url* string, run the chain of URL handlers and
@@ -205,11 +205,11 @@ class LinkInfo(Plugin):
             # Invoke the default handler if not excluded
             else:
                 try:
-                    return self.scrape_html_title(url)
+                    return await self.scrape_html_title(url)
                 except requests.exceptions.ConnectionError:
                     return make_error('Connection error')
 
-    def scrape_html_title(self, url):
+    async def scrape_html_title(self, url):
         """Scrape the ``<title>`` tag contents from the HTML page at *url*.
 
         Returns a :class:`LinkInfoResult`.

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -12,7 +12,7 @@ import lxml.etree
 import lxml.html
 
 from ..plugin import Plugin
-from ..util import Struct
+from ..util import Struct, simple_http_get_async
 
 
 LinkInfoHandler = namedtuple('LinkInfoHandler', ['filter', 'handler', 'exclusive'])
@@ -217,7 +217,7 @@ class LinkInfo(Plugin):
         make_error = partial(LinkInfoResult, url.geturl(), is_error=True)
 
         # Let's see what's on the other end...
-        async with aiohttp.ClientSession() as session, session.get(url.geturl()) as r:
+        async with simple_http_get_async(url.geturl()) as r:
             # Only bother with 200 OK
             if r.status != 200:
                 return make_error('HTTP request failed: {} {}'

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -12,7 +12,7 @@ import lxml.etree
 import lxml.html
 
 from ..plugin import Plugin
-from ..util import Struct, simple_http_get_async
+from ..util import Struct, simple_http_get_async, maybe_future_result
 
 
 LinkInfoHandler = namedtuple('LinkInfoHandler', ['filter', 'handler', 'exclusive'])
@@ -186,10 +186,7 @@ class LinkInfo(Plugin):
         for h in self.handlers:
             match = h.filter(url)
             if match:
-                if asyncio.iscoroutinefunction(h.handler):
-                    result = await h.handler(url, match)
-                else:
-                    result = h.handler(url, match)
+                result = await maybe_future_result(h.handler(url, match), log=self.log)
                 if result is not None:
                     # Useful result, return it
                     return result

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -206,7 +206,7 @@ class LinkInfo(Plugin):
             else:
                 try:
                     return await self.scrape_html_title(url)
-                except requests.exceptions.ConnectionError:
+                except aiohttp.ClientConnectionError:
                     return make_error('Connection error')
 
     async def scrape_html_title(self, url):

--- a/csbot/plugins/linkinfo.py
+++ b/csbot/plugins/linkinfo.py
@@ -5,7 +5,6 @@ import collections
 from collections import namedtuple
 import datetime
 from functools import partial
-import asyncio
 
 import aiohttp
 import lxml.etree

--- a/csbot/plugins/xkcd.py
+++ b/csbot/plugins/xkcd.py
@@ -1,9 +1,8 @@
 import html
 import random
-import requests
 
 from ..plugin import Plugin
-from ..util import simple_http_get, cap_string, is_ascii
+from ..util import simple_http_get_async, cap_string, is_ascii
 from .linkinfo import LinkInfoResult
 
 
@@ -29,7 +28,7 @@ def fix_json_unicode(data):
     return data
 
 
-def get_info(number=None):
+async def get_info(number=None):
     """Gets the json data for a particular comic
     (or the latest, if none provided).
     """
@@ -38,13 +37,13 @@ def get_info(number=None):
     else:
         url = "http://xkcd.com/info.0.json"
 
-    httpdata = simple_http_get(url)
-    if httpdata.status_code != requests.codes.ok:
-        return None
+    async with simple_http_get_async(url) as httpdata:
+        if httpdata.status != 200:
+            return None
 
-    # Only care about part of the data
-    httpjson = httpdata.json()
-    data = {key: httpjson[key] for key in ["title", "alt", "num"]}
+        # Only care about part of the data
+        httpjson = await httpdata.json()
+        data = {key: httpjson[key] for key in ["title", "alt", "num"]}
 
     # Unfuck up unicode strings
     data = fix_json_unicode(data)
@@ -61,12 +60,12 @@ class xkcd(Plugin):
     class XKCDError(Exception):
         pass
 
-    def _xkcd(self, user_str):
+    async def _xkcd(self, user_str):
         """Get the url and title stuff.
         Returns a string of the response.
         """
 
-        latest = get_info()
+        latest = await get_info()
         if not latest:
             raise self.XKCDError("Error getting comics")
 
@@ -75,12 +74,12 @@ class xkcd(Plugin):
         if not user_str or user_str in {'0', 'latest', 'current', 'newest'}:
             requested = latest
         elif user_str in {'rand', 'random'}:
-            requested = get_info(random.randint(1, latest_num))
+            requested = await get_info(random.randint(1, latest_num))
         else:
             try:
                 num = int(user_str)
                 if 1 <= num <= latest_num:
-                    requested = get_info(num)
+                    requested = await get_info(num)
                 else:
                     raise self.XKCDError("Comic #{} is invalid. The latest is #{}"
                                          .format(num, latest_num))
@@ -95,18 +94,18 @@ class xkcd(Plugin):
         return (requested["url"], requested["title"],
                 cap_string(requested["alt"], 120))
 
-    @Plugin.integrate_with('linkinfo')
+    # @Plugin.integrate_with('linkinfo')
     def linkinfo_integrate(self, linkinfo):
         """Handle recognised xkcd urls."""
 
-        def page_handler(url, match):
+        async def page_handler(url, match):
             """Use the main _xkcd function, then modify
             the result (if success) so it looks nicer.
             """
 
             # Remove leading and trailing '/'
             try:
-                response = self._xkcd(url.path.strip('/'))
+                response = await self._xkcd(url.path.strip('/'))
                 return LinkInfoResult(url.geturl(), '{1} - "{2}"'.format(*response))
             except self.XKCDError:
                 return None

--- a/csbot/plugins/xkcd.py
+++ b/csbot/plugins/xkcd.py
@@ -94,7 +94,7 @@ class xkcd(Plugin):
         return (requested["url"], requested["title"],
                 cap_string(requested["alt"], 120))
 
-    # @Plugin.integrate_with('linkinfo')
+    @Plugin.integrate_with('linkinfo')
     def linkinfo_integrate(self, linkinfo):
         """Handle recognised xkcd urls."""
 

--- a/csbot/test/conftest.py
+++ b/csbot/test/conftest.py
@@ -105,8 +105,7 @@ class IRCClientHelper:
         """Shortcut to push a series of lines to the client."""
         if isinstance(lines, str):
             lines = [lines]
-        for l in lines:
-            self.client.line_received(l)
+        return [self.client.line_received(l) for l in lines]
 
     def assert_sent(self, lines):
         """Check that a list of (unicode) strings have been sent.

--- a/csbot/test/conftest.py
+++ b/csbot/test/conftest.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 import aiofastforward
 import responses as responses_
+from aioresponses import aioresponses as aioresponses_
 
 from csbot import test
 from csbot.irc import IRCClient
@@ -176,3 +177,9 @@ class BotHelper(IRCClientHelper):
 def responses():
     with responses_.RequestsMock() as rsps:
         yield rsps
+
+
+@pytest.fixture
+def aioresponses():
+    with aioresponses_() as m:
+        yield m

--- a/csbot/test/test_bot.py
+++ b/csbot/test/test_bot.py
@@ -1,0 +1,66 @@
+import unittest.mock as mock
+import asyncio
+
+import pytest
+
+from csbot import core
+from csbot.plugin import Plugin
+
+
+class TestHookOrdering:
+    class Bot(core.Bot):
+        class MockPlugin(Plugin):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.handler_mock = mock.Mock(spec=callable)
+
+            @Plugin.hook('core.message.privmsg')
+            async def privmsg(self, event):
+                await asyncio.sleep(0.5)
+                self.handler_mock('privmsg', event['message'])
+
+            @Plugin.hook('core.user.quit')
+            def quit(self, event):
+                self.handler_mock('quit', event['user'])
+
+        available_plugins = core.Bot.available_plugins.copy()
+        available_plugins.update(
+            mockplugin=MockPlugin,
+        )
+
+    CONFIG = f"""\
+    [@bot]
+    plugins = mockplugin
+    """
+    pytestmark = pytest.mark.bot(cls=Bot, config=CONFIG)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('n', list(range(1, 10)))
+    async def test_burst_in_order(self, bot_helper, n):
+        """Check that a plugin always gets messages in receive order."""
+        plugin = bot_helper['mockplugin']
+        users = [f':nick{i}!user{i}@host{i}' for i in range(n)]
+        messages = [f':{user} QUIT :*.net *.split' for user in users]
+        await asyncio.wait(bot_helper.receive(messages))
+        assert plugin.handler_mock.mock_calls == [mock.call('quit', user) for user in users]
+
+    @pytest.mark.asyncio
+    async def test_non_blocking(self, bot_helper):
+        plugin = bot_helper['mockplugin']
+        messages = [
+            ':nick0!user@host QUIT :bye',
+            ':nick1!user@host QUIT :bye',
+            ':foo!user@host PRIVMSG #channel :hello',
+            ':nick2!user@host QUIT :bye',
+            ':nick3!user@host QUIT :bye',
+            ':nick4!user@host QUIT :bye',
+        ]
+        await asyncio.wait(bot_helper.receive(messages))
+        assert plugin.handler_mock.mock_calls == [
+            mock.call('quit', 'nick0!user@host'),
+            mock.call('quit', 'nick1!user@host'),
+            mock.call('quit', 'nick2!user@host'),
+            mock.call('quit', 'nick3!user@host'),
+            mock.call('quit', 'nick4!user@host'),
+            mock.call('privmsg', 'hello'),
+        ]

--- a/csbot/test/test_events.py
+++ b/csbot/test/test_events.py
@@ -339,7 +339,7 @@ class TestHybridEventRunner:
             mock.call('a'),
         ]
         assert complete == ['a1']
-        
+
         # Unblock a2 and allow some tasks to run:
         # - a2 should complete
         # - post_event('b') should be called (by a2)
@@ -359,7 +359,7 @@ class TestHybridEventRunner:
             mock.call('f'),
         ]
         assert complete == ['a1', 'a2', 'b1', 'b2', 'c', 'd']
-        
+
         # Unblock b3 and allow some tasks to run:
         # - b3 should complete
         # - post_event('e') should be called (by b3)

--- a/csbot/test/test_irc.py
+++ b/csbot/test/test_irc.py
@@ -315,8 +315,8 @@ async def test_wait_for_success(irc_client_helper):
         IRCMessage(None, 'PING', ['2'], 'PING', 'PING :2'),
     ]
 
-    mock_predicate = mock.Mock(return_value=False)
-    fut_mock = irc_client_helper.client.wait_for(mock_predicate)
+    mock_predicate = mock.Mock(return_value=(False, None))
+    fut_mock = irc_client_helper.client.wait_for_message(mock_predicate)
 
     # Predicate is called, but future is not resolved
     irc_client_helper.receive(messages[0].raw)
@@ -326,14 +326,14 @@ async def test_wait_for_success(irc_client_helper):
     assert not fut_mock.done()
 
     # Predicate is called, and future is resolved with matching message
-    mock_predicate.return_value = True
+    mock_predicate.return_value = (True, 'foo')
     irc_client_helper.receive(messages[1].raw)
     assert mock_predicate.mock_calls == [
         mock.call(messages[0]),
         mock.call(messages[1]),
     ]
     assert fut_mock.done()
-    assert fut_mock.result() == messages[1]
+    assert fut_mock.result() == 'foo'
 
     # Predicate is not called, because once resolved it was removed
     irc_client_helper.receive(messages[2].raw)
@@ -350,8 +350,8 @@ async def test_wait_for_cancelled(irc_client_helper):
         IRCMessage(None, 'PING', ['1'], 'PING', 'PING :1'),
     ]
 
-    mock_predicate = mock.Mock(return_value=False)
-    fut_mock = irc_client_helper.client.wait_for(mock_predicate)
+    mock_predicate = mock.Mock(return_value=(False, None))
+    fut_mock = irc_client_helper.client.wait_for_message(mock_predicate)
 
     # Predicate is called, but future is not resolved
     irc_client_helper.receive(messages[0].raw)
@@ -376,7 +376,7 @@ async def test_wait_for_exception(irc_client_helper):
     ]
 
     mock_predicate = mock.Mock(side_effect=Exception())
-    fut_mock = irc_client_helper.client.wait_for(mock_predicate)
+    fut_mock = irc_client_helper.client.wait_for_message(mock_predicate)
 
     # Predicate is called, but future has exception
     irc_client_helper.receive(messages[0].raw)

--- a/csbot/test/test_irc.py
+++ b/csbot/test/test_irc.py
@@ -307,6 +307,67 @@ def test_parse_failure(irc_client_helper):
         irc_client_helper.receive('')
 
 
+@pytest.mark.asyncio
+async def test_wait_for_success(irc_client_helper):
+    messages = [
+        IRCMessage(None, 'PING', ['0'], 'PING', 'PING :0'),
+        IRCMessage(None, 'PING', ['1'], 'PING', 'PING :1'),
+        IRCMessage(None, 'PING', ['2'], 'PING', 'PING :2'),
+    ]
+
+    mock_predicate = mock.Mock(return_value=False)
+    fut_mock = irc_client_helper.client.wait_for(mock_predicate)
+
+    # Predicate is called, but future is not resolved
+    irc_client_helper.receive(messages[0].raw)
+    assert mock_predicate.mock_calls == [
+        mock.call(messages[0]),
+    ]
+    assert not fut_mock.done()
+
+    # Predicate is called, and future is resolved with matching message
+    mock_predicate.return_value = True
+    irc_client_helper.receive(messages[1].raw)
+    assert mock_predicate.mock_calls == [
+        mock.call(messages[0]),
+        mock.call(messages[1]),
+    ]
+    assert fut_mock.done()
+    assert fut_mock.result() == messages[1]
+
+    # Predicate is not called, because once resolved it was removed
+    irc_client_helper.receive(messages[2].raw)
+    assert mock_predicate.mock_calls == [
+        mock.call(messages[0]),
+        mock.call(messages[1]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cancelled(irc_client_helper):
+    messages = [
+        IRCMessage(None, 'PING', ['0'], 'PING', 'PING :0'),
+        IRCMessage(None, 'PING', ['1'], 'PING', 'PING :1'),
+    ]
+
+    mock_predicate = mock.Mock(return_value=False)
+    fut_mock = irc_client_helper.client.wait_for(mock_predicate)
+
+    # Predicate is called, but future is not resolved
+    irc_client_helper.receive(messages[0].raw)
+    assert mock_predicate.mock_calls == [
+        mock.call(messages[0]),
+    ]
+    assert not fut_mock.done()
+
+    # Predicate is not called, because future was cancelled
+    fut_mock.cancel()
+    irc_client_helper.receive(messages[1].raw)
+    assert mock_predicate.mock_calls == [
+        mock.call(messages[0]),
+    ]
+
+
 # Test that calling various commands causes the appropriate messages to be sent to the server
 
 def test_set_nick(irc_client_helper):

--- a/csbot/test/test_plugin_github.py
+++ b/csbot/test/test_plugin_github.py
@@ -54,7 +54,7 @@ class TestGitHubPlugin:
     fmt.issue_text = {issue[title]} ({issue[html_url]})
     fmt.pr_num = PR #{pull_request[number]}
     fmt.pr_text = {pull_request[title]} ({pull_request[html_url]})
-    
+
     # Format strings for specific events
     fmt/create = {fmt.source} created {ref_type} {ref} ({repository[html_url]}/tree/{ref})
     fmt/delete = {fmt.source} deleted {ref_type} {ref}
@@ -67,7 +67,7 @@ class TestGitHubPlugin:
     fmt/push/pushed = {fmt.source} pushed {count} new commit(s) to {short_ref}: {compare}
     fmt/push/forced = {fmt.source} updated {short_ref}: {compare}
     fmt/release/* = {fmt.source} {event_subtype} release {release[name]}: {release[html_url]}
-    
+
     [github/alanbriolat/csbot-webhook-test]
     notify = #mychannel
     """
@@ -217,7 +217,7 @@ plugins = webserver webhook github
 [webhook]
 url_secret = test_url
 [github]
-secret = 
+secret =
 """)
 async def test_signature_ignored(bot_helper, client):
     """X-Hub-Signature invalid, but secret is blank, so not verified and handler called"""

--- a/csbot/test/test_plugin_imgur.py
+++ b/csbot/test/test_plugin_imgur.py
@@ -164,20 +164,12 @@ pytestmark = pytest.mark.bot(config="""\
     """)
 
 
-@pytest.fixture
-def pre_irc_client(responses):
-    # imgurpython calls this on init to get initial rate limits
-    responses.add(responses.GET, 'https://api.imgur.com/3/credits',
-                  status=200, body=read_fixture_file('imgur_credits.json'),
-                  content_type='application/json')
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("url, api_url, status, content_type, fixture, title", test_cases)
-async def test_integration(bot_helper, responses, url, api_url, status, content_type, fixture, title):
-    responses.add(responses.GET, api_url, status=status,
-                  body=read_fixture_file(fixture),
-                  content_type=content_type)
+async def test_integration(bot_helper, aioresponses, url, api_url, status, content_type, fixture, title):
+    aioresponses.get(api_url, status=status,
+                     body=read_fixture_file(fixture),
+                     content_type=content_type)
     result = await bot_helper['linkinfo'].get_link_info(url)
     if title is None:
         assert result.is_error
@@ -188,10 +180,10 @@ async def test_integration(bot_helper, responses, url, api_url, status, content_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("url, api_url, status, content_type, fixture, title", nsfw_test_cases)
-async def test_integration_nsfw(bot_helper, responses, url, api_url, status, content_type, fixture, title):
-    responses.add(responses.GET, api_url, status=status,
-                  body=read_fixture_file(fixture),
-                  content_type=content_type)
+async def test_integration_nsfw(bot_helper, aioresponses, url, api_url, status, content_type, fixture, title):
+    aioresponses.get(api_url, status=status,
+                     body=read_fixture_file(fixture),
+                     content_type=content_type)
     result = await bot_helper['linkinfo'].get_link_info(url)
     if title is None:
         assert result.is_error
@@ -201,9 +193,7 @@ async def test_integration_nsfw(bot_helper, responses, url, api_url, status, con
 
 
 @pytest.mark.asyncio
-async def test_invalid_URL(bot_helper, responses):
+async def test_invalid_URL(bot_helper, aioresponses):
     """Test that an unrecognised URL never even results in a request."""
-    responses.reset()   # Drop requests used/made during plugin setup
     result = await bot_helper['linkinfo'].get_link_info('http://imgur.com/invalid/url')
     assert result.is_error
-    assert len(responses.calls) == 0

--- a/csbot/test/test_plugin_imgur.py
+++ b/csbot/test/test_plugin_imgur.py
@@ -172,12 +172,13 @@ def pre_irc_client(responses):
                   content_type='application/json')
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("url, api_url, status, content_type, fixture, title", test_cases)
-def test_integration(bot_helper, responses, url, api_url, status, content_type, fixture, title):
+async def test_integration(bot_helper, responses, url, api_url, status, content_type, fixture, title):
     responses.add(responses.GET, api_url, status=status,
                   body=read_fixture_file(fixture),
                   content_type=content_type)
-    result = bot_helper['linkinfo'].get_link_info(url)
+    result = await bot_helper['linkinfo'].get_link_info(url)
     if title is None:
         assert result.is_error
     else:
@@ -185,12 +186,13 @@ def test_integration(bot_helper, responses, url, api_url, status, content_type, 
         assert title == result.text
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("url, api_url, status, content_type, fixture, title", nsfw_test_cases)
-def test_integration_nsfw(bot_helper, responses, url, api_url, status, content_type, fixture, title):
+async def test_integration_nsfw(bot_helper, responses, url, api_url, status, content_type, fixture, title):
     responses.add(responses.GET, api_url, status=status,
                   body=read_fixture_file(fixture),
                   content_type=content_type)
-    result = bot_helper['linkinfo'].get_link_info(url)
+    result = await bot_helper['linkinfo'].get_link_info(url)
     if title is None:
         assert result.is_error
     else:
@@ -198,9 +200,10 @@ def test_integration_nsfw(bot_helper, responses, url, api_url, status, content_t
         assert title == result.text
 
 
-def test_invalid_URL(bot_helper, responses):
+@pytest.mark.asyncio
+async def test_invalid_URL(bot_helper, responses):
     """Test that an unrecognised URL never even results in a request."""
     responses.reset()   # Drop requests used/made during plugin setup
-    result = bot_helper['linkinfo'].get_link_info('http://imgur.com/invalid/url')
+    result = await bot_helper['linkinfo'].get_link_info('http://imgur.com/invalid/url')
     assert result.is_error
     assert len(responses.calls) == 0

--- a/csbot/test/test_plugin_linkinfo.py
+++ b/csbot/test/test_plugin_linkinfo.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 from lxml.etree import LIBXML_VERSION
 import unittest.mock as mock
+import urllib.parse as urlparse
 
 import pytest
 import asynctest.mock
-import requests
-
-from csbot.util import simple_http_get
+import aiohttp
 
 
 #: Test encoding handling; tests are (url, content-type, body, expected_title)
@@ -142,8 +141,10 @@ async def irc_client(irc_client):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("url, content_type, body, expected_title", encoding_test_cases,
                          ids=[_[0] for _ in encoding_test_cases])
-async def test_encoding_handling(bot_helper, responses, url, content_type, body, expected_title):
-    responses.add(responses.GET, url, body=body, content_type=content_type, stream=True)
+async def test_encoding_handling(bot_helper, aresponses, url, content_type, body, expected_title):
+    parsed_url = urlparse.urlparse(url)
+    aresponses.add(parsed_url.hostname, parsed_url.path, 'get',
+                   aresponses.Response(body=body, headers={'Content-Type': content_type}))
     result = await bot_helper['linkinfo'].get_link_info(url)
     assert result.text == expected_title
 
@@ -151,27 +152,31 @@ async def test_encoding_handling(bot_helper, responses, url, content_type, body,
 @pytest.mark.asyncio
 @pytest.mark.parametrize("url, content_type, body", error_test_cases,
                          ids=[_[0] for _ in error_test_cases])
-async def test_html_title_errors(bot_helper, responses, url, content_type, body):
-    responses.add(responses.GET, url, body=body,
-                  content_type=content_type, stream=True)
+async def test_html_title_errors(bot_helper, aresponses, url, content_type, body):
+    parsed_url = urlparse.urlparse(url)
+    aresponses.add(parsed_url.hostname, parsed_url.path, 'get',
+                   aresponses.Response(body=body, headers={'Content-Type': content_type}))
     result = await bot_helper['linkinfo'].get_link_info(url)
     assert result.is_error
 
 
 @pytest.mark.asyncio
-async def test_connection_error(bot_helper, responses):
-    # Check our assumptions: should be connection error because "responses" library is mocking the internet
-    with pytest.raises(requests.ConnectionError):
-        simple_http_get('http://example.com/foo/bar')
+async def test_not_found(bot_helper, aresponses):
+    # Test our assumptions: direct request should return a 404
+    aresponses.add(aresponses.ANY, aresponses.ANY, aresponses.ANY, lambda r: aresponses.Response(status=404))
+    async with aiohttp.ClientSession() as session, session.get('http://example.com/') as resp:
+        assert resp.status == 404
+
     # Should result in an error message from linkinfo (and implicitly no exception raised)
-    result = await bot_helper['linkinfo'].get_link_info('http://example.com/foo/bar')
+    aresponses.add(aresponses.ANY, aresponses.ANY, aresponses.ANY, lambda r: aresponses.Response(status=404))
+    result = await bot_helper['linkinfo'].get_link_info('http://example.com/')
     assert result.is_error
 
 
 @pytest.mark.usefixtures("run_client")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("msg, urls", [('http://example.com', ['http://example.com'])])
-async def test_scan_privmsg(event_loop, bot_helper, msg, urls):
+async def test_scan_privmsg(event_loop, bot_helper, aresponses, msg, urls):
     with asynctest.mock.patch.object(bot_helper['linkinfo'], 'get_link_info') as get_link_info:
         await bot_helper.client.line_received(':nick!user@host PRIVMSG #channel :' + msg)
         get_link_info.assert_has_calls([mock.call(url) for url in urls])
@@ -179,7 +184,7 @@ async def test_scan_privmsg(event_loop, bot_helper, msg, urls):
 
 @pytest.mark.usefixtures("run_client")
 @pytest.mark.asyncio
-def test_scan_privmsg_rate_limit(bot_helper):
+def test_scan_privmsg_rate_limit(bot_helper, aresponses):
     """Test that we won't respond too frequently to URLs in messages.
 
     Unfortunately we can't currently test the passage of time, so the only

--- a/csbot/test/test_plugin_linkinfo.py
+++ b/csbot/test/test_plugin_linkinfo.py
@@ -272,7 +272,6 @@ class TestNonBlocking:
 
     @pytest.mark.asyncio
     async def test_non_blocking_command(self, event_loop, bot_helper, aioresponses):
-        # TODO: use aioresponses instead, once it supports async callbacks
         bot_helper.reset_mock()
 
         event = asyncio.Event(loop=event_loop)

--- a/csbot/test/test_plugin_linkinfo.py
+++ b/csbot/test/test_plugin_linkinfo.py
@@ -133,8 +133,8 @@ pytestmark = pytest.mark.bot(config="""\
 
 
 @pytest.fixture
-def irc_client(irc_client):
-    irc_client.connection_made()
+async def irc_client(irc_client):
+    await irc_client.connection_made()
     return irc_client
 
 

--- a/csbot/test/test_plugin_linkinfo.py
+++ b/csbot/test/test_plugin_linkinfo.py
@@ -165,7 +165,7 @@ async def test_not_found(bot_helper, aioresponses):
     # Test our assumptions: direct request should raise connection error, because aioresponses
     # is mocking the internet
     with pytest.raises(aiohttp.ClientConnectionError):
-        async with aiohttp.ClientSession() as session, session.get('http://example.com/') as resp:
+        async with aiohttp.ClientSession() as session, session.get('http://example.com/'):
             pass
 
     # Should result in an error message from linkinfo (and implicitly no exception raised)

--- a/csbot/test/test_plugin_xkcd.py
+++ b/csbot/test/test_plugin_xkcd.py
@@ -156,17 +156,19 @@ class TestXKCDLinkInfoIntegration:
                           content_type=content_type)
 
     @pytest.mark.usefixtures("populate_responses")
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("num, url, content_type, fixture, expected", json_test_cases,
                              ids=[_[1] for _ in json_test_cases])
-    def test_integration(self, bot_helper, num, url, content_type, fixture, expected):
+    async def test_integration(self, bot_helper, num, url, content_type, fixture, expected):
         _, title, alt = expected
         url = 'http://xkcd.com/{}'.format(num)
-        result = bot_helper['linkinfo'].get_link_info(url)
+        result = await bot_helper['linkinfo'].get_link_info(url)
         assert title in result.text
         assert alt in result.text
 
     @pytest.mark.usefixtures("populate_responses")
-    def test_integration_error(self, bot_helper):
+    @pytest.mark.asyncio
+    async def test_integration_error(self, bot_helper):
         # Error case
-        result = bot_helper['linkinfo'].get_link_info("http://xkcd.com/flibble")
+        result = await bot_helper['linkinfo'].get_link_info("http://xkcd.com/flibble")
         assert result.is_error

--- a/csbot/test/test_plugin_xkcd.py
+++ b/csbot/test/test_plugin_xkcd.py
@@ -87,48 +87,54 @@ json_test_cases = [
     """)
 class TestXKCDPlugin:
     @pytest.fixture
-    def populate_responses(self, bot_helper, responses):
-        """Populate all data into responses, don't assert that every request is fired."""
-        responses.assert_all_requests_are_fired = False
+    def populate_responses(self, bot_helper, aioresponses):
+        """Populate all data into responses."""
         for num, url, content_type, fixture, expected in json_test_cases:
-            responses.add(responses.GET, url, body=read_fixture_file(fixture),
-                          content_type=content_type)
+            aioresponses.add(url, body=read_fixture_file(fixture),
+                             content_type=content_type)
 
+    @pytest.mark.asyncio
     @pytest.mark.usefixtures("populate_responses")
     @pytest.mark.parametrize("num, url, content_type, fixture, expected", json_test_cases,
                              ids=[_[1] for _ in json_test_cases])
-    def test_correct(self, bot_helper, num, url, content_type, fixture, expected):
-        result = bot_helper['xkcd']._xkcd(num)
+    async def test_correct(self, bot_helper, num, url, content_type, fixture, expected):
+        result = await bot_helper['xkcd']._xkcd(num)
         assert result == expected
 
+    @pytest.mark.asyncio
     @pytest.mark.usefixtures("populate_responses")
-    def test_latest_success(self, bot_helper):
+    async def test_latest_success(self, bot_helper):
         # Also test the empty string
         num, url, content_type, fixture, expected = json_test_cases[0]
-        assert bot_helper['xkcd']._xkcd("") == expected
+        assert await bot_helper['xkcd']._xkcd("") == expected
 
+    @pytest.mark.asyncio
     @pytest.mark.usefixtures("populate_responses")
-    def test_random(self, bot_helper):
+    async def test_random(self, bot_helper):
         # !xkcd 221
         num, url, content_type, fixture, expected = json_test_cases[1]
         with patch("random.randint", return_value=1):
-            assert bot_helper['xkcd']._xkcd("rand") == expected
+            assert await bot_helper['xkcd']._xkcd("rand") == expected
 
-    def test_error(self, bot_helper, responses):
+    @pytest.mark.asyncio
+    async def test_error_1(self, bot_helper, aioresponses):
         num, url, content_type, fixture, _ = json_test_cases[0]  # Latest
         # Test if the comics are unavailable by making the latest return a 404
-        responses.add(responses.GET, url, body="404 - Not Found",
-                      content_type="text/html", status=404)
+        aioresponses.get(url, body="404 - Not Found",
+                         content_type="text/html", status=404)
         with pytest.raises(bot_helper['xkcd'].XKCDError):
-            bot_helper['xkcd']._xkcd("")
-        responses.reset()
+            await bot_helper['xkcd']._xkcd("")
 
+    @pytest.mark.asyncio
+    async def test_error_2(self, bot_helper, aioresponses):
+        num, url, content_type, fixture, _ = json_test_cases[0]  # Latest
         # Now override the actual 404 page and the latest "properly"
-        responses.add(responses.GET, url, body=read_fixture_file(fixture),
-                      content_type=content_type)
-        responses.add(responses.GET, "http://xkcd.com/404/info.0.json",
-                      body="404 - Not Found", content_type="text/html",
-                      status=404)
+        aioresponses.get(url, body=read_fixture_file(fixture),
+                         content_type=content_type,
+                         repeat=True)
+        aioresponses.get("http://xkcd.com/404/info.0.json",
+                         body="404 - Not Found", content_type="text/html",
+                         status=404)
 
         error_cases = [
             "flibble",
@@ -139,9 +145,10 @@ class TestXKCDPlugin:
 
         for case in error_cases:
             with pytest.raises(bot_helper['xkcd'].XKCDError):
-                bot_helper['xkcd']._xkcd(case)
+                await bot_helper['xkcd']._xkcd(case)
 
 
+@pytest.mark.skip
 @pytest.mark.bot(config="""\
     [@bot]
     plugins = linkinfo xkcd

--- a/csbot/test/test_plugin_xkcd.py
+++ b/csbot/test/test_plugin_xkcd.py
@@ -148,19 +148,17 @@ class TestXKCDPlugin:
                 await bot_helper['xkcd']._xkcd(case)
 
 
-@pytest.mark.skip
 @pytest.mark.bot(config="""\
     [@bot]
     plugins = linkinfo xkcd
     """)
 class TestXKCDLinkInfoIntegration:
     @pytest.fixture
-    def populate_responses(self, bot_helper, responses):
-        """Populate all data into responses, don't assert that every request is fired."""
-        responses.assert_all_requests_are_fired = False
+    def populate_responses(self, bot_helper, aioresponses):
+        """Populate all data into responses."""
         for num, url, content_type, fixture, expected in json_test_cases:
-            responses.add(responses.GET, url, body=read_fixture_file(fixture),
-                          content_type=content_type)
+            aioresponses.get(url, body=read_fixture_file(fixture),
+                             content_type=content_type)
 
     @pytest.mark.usefixtures("populate_responses")
     @pytest.mark.asyncio

--- a/csbot/test/test_plugin_youtube.py
+++ b/csbot/test/test_plugin_youtube.py
@@ -125,6 +125,7 @@ class TestYoutubeLinkInfoIntegration:
             })
         return bot_helper
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("vid_id, status, fixture, response", json_test_cases)
     @pytest.mark.parametrize("url", [
         "https://www.youtube.com/watch?v={}",
@@ -133,11 +134,11 @@ class TestYoutubeLinkInfoIntegration:
         "http://www.youtube.com/watch?v={}&feature=youtube_gdata_player",
         "http://youtu.be/{}",
     ])
-    def test_integration(self, bot_helper, vid_id, status, fixture, response, url):
+    async def test_integration(self, bot_helper, vid_id, status, fixture, response, url):
         http = apiclient.http.HttpMock(fixture_file(fixture), {'status': status})
         with patch.object(bot_helper['youtube'], 'http', wraps=http):
             url = url.format(vid_id)
-            result = bot_helper['linkinfo'].get_link_info(url)
+            result = await bot_helper['linkinfo'].get_link_info(url)
             if response is None or response is YoutubeError:
                 assert result.is_error
             else:

--- a/csbot/test/test_plugin_youtube.py
+++ b/csbot/test/test_plugin_youtube.py
@@ -1,4 +1,3 @@
-from distutils.version import StrictVersion
 import re
 
 import pytest
@@ -90,7 +89,7 @@ def pre_irc_client(aioresponses):
 @pytest.mark.bot(config="""\
     [@bot]
     plugins = youtube
-    
+
     [youtube]
     api_key = abc
     """)
@@ -112,7 +111,7 @@ class TestYoutubePlugin:
 @pytest.mark.bot(config="""\
     [@bot]
     plugins = linkinfo youtube
-    
+
     [youtube]
     api_key = abc
     """)

--- a/csbot/util.py
+++ b/csbot/util.py
@@ -3,6 +3,8 @@ from itertools import tee
 from collections import OrderedDict
 
 import requests
+from async_generator import asynccontextmanager
+import aiohttp
 
 
 class User(object):
@@ -94,6 +96,21 @@ def simple_http_get(url, stream=False):
     """
     headers = {'User-Agent': 'csbot/0.1'}
     return requests.get(url, verify=False, headers=headers, stream=stream)
+
+
+@asynccontextmanager
+async def simple_http_get_async(url):
+    session_kwargs = {
+        'headers': {
+            'User-Agent': 'csbot/0.1',
+        },
+    }
+    get_kwargs = {
+        'ssl': False,
+    }
+    async with aiohttp.ClientSession(**session_kwargs) as session:
+        async with session.get(url, **get_kwargs) as resp:
+            yield resp
 
 
 def pairwise(iterable):

--- a/csbot/util.py
+++ b/csbot/util.py
@@ -99,17 +99,15 @@ def simple_http_get(url, stream=False):
 
 
 @asynccontextmanager
-async def simple_http_get_async(url):
+async def simple_http_get_async(url, **kwargs):
     session_kwargs = {
         'headers': {
             'User-Agent': 'csbot/0.1',
         },
     }
-    get_kwargs = {
-        'ssl': False,
-    }
+    kwargs.setdefault('ssl', False)
     async with aiohttp.ClientSession(**session_kwargs) as session:
-        async with session.get(url, **get_kwargs) as resp:
+        async with session.get(url, **kwargs) as resp:
             yield resp
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ rollbar
 pytest==4.2.0
 pytest-asyncio==0.10.0
 pytest-aiohttp==0.3.0
-aresponses==1.1.1
-aioresponses==0.6.0
+#aioresponses==0.6.0
+git+https://github.com/alanbriolat/aioresponses.git@callback-coroutines#egg=aioresponses
 pytest-cov==2.6.1
 asynctest==0.12.2
 aiofastforward==0.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ straight.plugin==1.4.0-post-1
 pymongo>=3.6.0
 requests>=2.9.1,<3.0.0
 lxml>=2.3.5
-#aiogoogle==0.1.11
-git+https://github.com/alanbriolat/aiogoogle.git@py36#egg=aiogoogle
+aiogoogle==0.1.13
 isodate>=0.5.1
 aiohttp>=3.5.1,<4.0
 async_generator>=1.10,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ requests>=2.9.1,<3.0.0
 lxml>=2.3.5
 google-api-python-client>=1.4.1,<2.0.0
 oauth2client>=3,<4      # google-api-python-client dropped dep in a minor release, generates ImportError warnings
-imgurpython>=1.1.6,<2.0.0
 isodate>=0.5.1
 aiohttp>=3.5.1,<4.0
 async_generator>=1.10,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pytest==4.2.0
 pytest-asyncio==0.10.0
 pytest-aiohttp==0.3.0
 aresponses==1.1.1
+aioresponses==0.6.0
 pytest-cov==2.6.1
 asynctest==0.12.2
 aiofastforward==0.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ straight.plugin==1.4.0-post-1
 pymongo>=3.6.0
 requests>=2.9.1,<3.0.0
 lxml>=2.3.5
-aiogoogle==0.1.11
+#aiogoogle==0.1.11
+git+https://github.com/alanbriolat/aiogoogle.git@py36#egg=aiogoogle
 isodate>=0.5.1
 aiohttp>=3.5.1,<4.0
 async_generator>=1.10,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ straight.plugin==1.4.0-post-1
 pymongo>=3.6.0
 requests>=2.9.1,<3.0.0
 lxml>=2.3.5
-google-api-python-client>=1.4.1,<2.0.0
-oauth2client>=3,<4      # google-api-python-client dropped dep in a minor release, generates ImportError warnings
+aiogoogle==0.1.11
 isodate>=0.5.1
 aiohttp>=3.5.1,<4.0
 async_generator>=1.10,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ oauth2client>=3,<4      # google-api-python-client dropped dep in a minor releas
 imgurpython>=1.1.6,<2.0.0
 isodate>=0.5.1
 aiohttp>=3.5.1,<4.0
+async_generator>=1.10,<2.0
 rollbar
 
 # Requirements for unit testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ rollbar
 pytest==4.2.0
 pytest-asyncio==0.10.0
 pytest-aiohttp==0.3.0
+aresponses==1.1.1
 pytest-cov==2.6.1
 asynctest==0.12.2
 aiofastforward==0.0.17


### PR DESCRIPTION
Extends from #152 to generally make plugin behaviour synchronous unless explicitly asynchronous. This avoids a class of bugs that occur when handlers for different messages are run in an undefined order, creating inconsistent state in plugins (e.g. `usertrack` plugin).

* Events are processed in the order they are submitted with `post_event(e)`
* All synchronous handlers for an event finish executing before handling the next event
* Handlers that return awaitables (e.g. coroutine functions) complete asynchronously
* The future returned by `post_event(e)` completes when all synchronous and asynchronous handlers for all events have finished
* Commands (`@Plugin.command(...)`) and LinkInfo handlers (`linkinfo.register_handler(...)`) can also be awaitables/coroutines