### PR TITLE
Truncate outgoing messages

### DIFF
--- a/src/csbot/core.py
+++ b/src/csbot/core.py
@@ -214,8 +214,8 @@ class Bot(SpecialPlugin, IRCClient):
         await super().connection_lost(exc)
         self.emit_new('core.raw.disconnected', {'reason': repr(exc)})
 
-    def send_line(self, line):
-        super().send_line(line)
+    def line_sent(self, line: str):
+        super().line_sent(line)
         self.emit_new('core.raw.sent', {'message': line})
 
     def line_received(self, line):

--- a/src/csbot/irc.py
+++ b/src/csbot/irc.py
@@ -9,6 +9,7 @@ import types
 from typing import Callable, Tuple, Any, Iterable, Awaitable
 
 from ._rfc import NUMERIC_REPLIES
+from . import util
 
 
 LOG = logging.getLogger('csbot.irc')
@@ -220,7 +221,6 @@ class IRCClient:
     .. _Twisted: http://twistedmatrix.com/documents/14.0.0/api/twisted.words.protocols.irc.IRCClient.html
 
     * TODO: limit send rate
-    * TODO: limit PRIVMSG/NOTICE send length
     * TODO: NAMES
     * TODO: MODE
     * TODO: More sophisticated CTCP? (see Twisted_)
@@ -401,11 +401,16 @@ class IRCClient:
     def send_line(self, data):
         """Send a raw IRC message to the server.
 
-        Encodes, terminates and sends *data* to the server.
+        Encodes, terminates and sends *data* to the server. If the line would be longer than the
+        maximum allowed by the IRC specification, it is trimmed to fit (without breaking UTF-8
+        sequences).
         """
-        LOG.debug('<<< %s', data)
-        data = self.codec.encode(data) + b'\r\n'
-        self.writer.write(data)
+        encoded = self.codec.encode(data)
+        trimmed = util.truncate_utf8(encoded, 510)  # RFC line length is 512 including \r\n
+        if len(trimmed) < len(encoded):
+            LOG.warning(f"message trimmed from {len(encoded)} to {len(trimmed)} bytes")
+        LOG.debug('<<< %s', trimmed)
+        self.writer.write(trimmed + b"\r\n")
 
     def send(self, msg):
         """Send an :class:`IRCMessage`."""

--- a/src/csbot/util.py
+++ b/src/csbot/util.py
@@ -352,3 +352,18 @@ async def maybe_future_result(result, **kwargs):
         return await future
     else:
         return result
+
+
+def truncate_utf8(b: bytes, maxlen: int, ellipsis: bytes = b"...") -> bytes:
+    """Trim *b* to a maximum of *maxlen* bytes (including *ellipsis* if longer), without breaking UTF-8 sequences."""
+    if len(b) <= maxlen:
+        return b
+    # Cut down to 1 byte more than we need
+    b = b[:maxlen - len(ellipsis) + 1]
+    # Find the last non-continuation byte
+    for i in range(len(b) - 1, -1, -1):
+        if not 0x80 <= b[i] <= 0xBF:
+            # Break the string to exclude the last UTF-8 sequence
+            b = b[:i]
+            break
+    return b + ellipsis

--- a/tests/test_irc.py
+++ b/tests/test_irc.py
@@ -81,6 +81,14 @@ def test_encode(irc_client_helper):
     irc_client_helper.assert_bytes_sent(b'PRIVMSG #channel :\xe0\xb2\xa0_\xe0\xb2\xa0\r\n')
 
 
+def test_truncate(irc_client_helper):
+    """Check that outgoing lines are trimmed to the RFC specified length."""
+    data = "abcdefghijklmnopqrstuvwxyz" * 20
+    expected = b"PRIVMSG #channel :" + data.encode("utf-8")[:489] + b"...\r\n"
+    irc_client_helper.client.send_line("PRIVMSG #channel :" + data)
+    irc_client_helper.assert_bytes_sent(expected)
+
+
 # Test IRC client behaviour
 
 @pytest.mark.asyncio

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -58,3 +58,12 @@ async def test_maybe_future_result_coroutine():
 
     result = await util.maybe_future_result(foo())
     assert result == "bar"
+
+
+def test_truncate_utf8():
+    assert util.truncate_utf8(b"0123456789", 20) == b"0123456789"
+    assert util.truncate_utf8(b"0123456789", 10) == b"0123456789"
+    assert util.truncate_utf8(b"0123456789", 9) == b"012345..."
+    assert util.truncate_utf8(b"0123456789", 9, b"?") == b"01234567?"
+    assert util.truncate_utf8(b"\xE2\x98\xBA\xE2\x98\xBA\xE2\x98\xBA", 8, b"?") == b"\xE2\x98\xBA\xE2\x98\xBA?"
+    assert util.truncate_utf8(b"\xE2\x98\xBA\xE2\x98\xBA\xE2\x98\xBA", 8) == b"\xE2\x98\xBA..."


### PR DESCRIPTION
* Make sure sent messages fit inside the RFC-defined 512-byte limit.
* Log a warning when messages get truncated.
* Fixes #150.