### PR TITLE
Switch from GitHub Packages to GitHub Container Registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,17 +55,17 @@ jobs:
           tags: csbot:latest
       - name: Run tests inside Docker
         run: docker run --rm csbot:latest pytest
-      - name: Login to GitHub Packages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'push' && github.repository == 'HackSoc/csbot' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Docker image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.repository == 'HackSoc/csbot' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
           push: true
           tags: |
-            docker.pkg.github.com/hacksoc/csbot/csbot:latest
+            ghcr.io/hacksoc/csbot/csbot:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   bot:
-    image: docker.pkg.github.com/hacksoc/csbot/csbot:latest
+    image: ghcr.io/hacksoc/csbot/csbot:latest
     volumes:
       - ${CSBOT_CONFIG_LOCAL:-./csbot.toml}:/app/csbot.toml
     links:


### PR DESCRIPTION
GHCR is the "correct" way to push/pull Docker images to/from GitHub now. Added bonus of allowing unauthenticated pull, which means `watchtower` continues to work.