### PR TITLE
Change default branch name to "main"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize]
 
@@ -56,14 +56,14 @@ jobs:
       - name: Run tests inside Docker
         run: docker run --rm csbot:latest pytest
       - name: Login to GitHub Packages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v1
         with:
           registry: docker.pkg.github.com
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Docker image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
           push: true

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ We're also using GitHub Actions for continuous integration and continuous deploy
 
 .. image:: https://github.com/HackSoc/csbot/actions/workflows/main.yml/badge.svg
 
-.. image:: https://codecov.io/gh/HackSoc/csbot/branch/master/graph/badge.svg?token=oMJcY9E9lj
+.. image:: https://codecov.io/gh/HackSoc/csbot/branch/main/graph/badge.svg?token=oMJcY9E9lj
     :target: https://codecov.io/gh/HackSoc/csbot
 
 


### PR DESCRIPTION
The HackSoc committee has decided to rename the default branch on all HackSoc repos to "main"; this PR updates references to the default branch to reflect this.

It looks like there's a bunch of CI associated with this repo – what's the most sensible order to merge this and rename the default branch in? I suspect renaming the default branch then merging this will work best, but I'm not 100% sure.