### PR TITLE
Remove like/dislike from LinkInfo YouTube integration

### DIFF
--- a/src/csbot/plugins/youtube.py
+++ b/src/csbot/plugins/youtube.py
@@ -56,7 +56,7 @@ class Youtube(Plugin):
         'api_key': ['YOUTUBE_DATA_API_KEY'],
     }
 
-    RESPONSE = '"{title}" [{duration}] (by {uploader} at {uploaded}) | Views: {views} [{likes}]'
+    RESPONSE = '"{title}" [{duration}] (by {uploader} at {uploaded}) | Views: {views}'
     CMD_RESPONSE = RESPONSE + ' | {link}'
 
     async def get_video_json(self, id):
@@ -129,13 +129,6 @@ class Youtube(Plugin):
             vid_info["views"] = "{:,}".format(views)
         except KeyError:
             vid_info["views"] = "N/A"
-
-        try:
-            likes = int(json["statistics"]["likeCount"])
-            dislikes = int(json["statistics"]["dislikeCount"])
-            vid_info["likes"] = "+{:,}/-{:,}".format(likes, dislikes)
-        except KeyError:
-            vid_info["likes"] = "N/A"
 
         return vid_info
 

--- a/tests/test_plugin_youtube.py
+++ b/tests/test_plugin_youtube.py
@@ -18,7 +18,7 @@ json_test_cases = [
         "youtube_fItlK6L-khc.json",
         {'link': 'http://youtu.be/fItlK6L-khc', 'uploader': 'BruceWillakers',
          'uploaded': '2014-08-29', 'views': '28,843', 'duration': '21:00',
-         'likes': '+1,192/-13', 'title': 'Trouble In Terrorist Town | Hiding in Fire'}
+         'title': 'Trouble In Terrorist Town | Hiding in Fire'}
     ),
 
     # Unicode
@@ -26,7 +26,7 @@ json_test_cases = [
         "vZ_YpOvRd3o",
         200,
         "youtube_vZ_YpOvRd3o.json",
-        {'title': "Oh! it's just me! / Фух! Это всего лишь я!", 'likes': '+12,571/-155',
+        {'title': "Oh! it's just me! / Фух! Это всего лишь я!",
          'duration': '00:24', 'uploader': 'ignoramusky', 'uploaded': '2014-08-26',
          'views': '6,054,406', 'link': 'http://youtu.be/vZ_YpOvRd3o'}
     ),
@@ -36,7 +36,7 @@ json_test_cases = [
         "sw4hmqVPe0E",
         200,
         "youtube_sw4hmqVPe0E.json",
-        {'title': "Sky News Live", 'likes': '+2,195/-586',
+        {'title': "Sky News Live",
          'duration': 'LIVE', 'uploader': 'Sky News', 'uploaded': '2015-03-24',
          'views': '2,271,999', 'link': 'http://youtu.be/sw4hmqVPe0E'}
     ),
@@ -46,7 +46,7 @@ json_test_cases = [
         "539OnO-YImk",
         200,
         "youtube_539OnO-YImk.json",
-        {'title': 'sharpest Underwear kitchen knife in the world', 'likes': '+52,212/-2,209',
+        {'title': 'sharpest Underwear kitchen knife in the world',
          'duration': '12:24', 'uploader': '圧倒的不審者の極み!', 'uploaded': '2018-07-14',
          'views': '2,710,723', 'link': 'http://youtu.be/539OnO-YImk'}
     ),


### PR DESCRIPTION
YouTube is removing dislike counts from API responses on December 13th, 2021. The main reason for displaying likes at all was to display the like/dislike ratio. Since this will no longer be possible, I removed the "likes" part of the response entirely.